### PR TITLE
Add shadcn error fallback

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 // TEMP: Disabled for rebuild - FCX-30
 // import { useEffect } from "react";
 import { ErrorBoundary } from "react-error-boundary";
+import { ErrorFallback } from "@/components/error-fallback";
 // TEMP: Disabled for rebuild - FCX-30
 // import { hasActiveSession, getUser } from "@/utils/supabase/session";
 // import { useUserActions } from "@/store";
@@ -50,7 +51,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
   */
 
   return (
-    <ErrorBoundary fallback={<div>Something went wrong</div>}>
+    <ErrorBoundary FallbackComponent={ErrorFallback}>
       <QueryClientProvider client={queryClient}>
         {children}
         <ReactQueryDevtools initialIsOpen={false} />

--- a/components/error-fallback.tsx
+++ b/components/error-fallback.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+/**
+ * Error fallback component displayed when an error boundary catches an error.
+ *
+ * Renders a Shadcn dialog with the error message and a button to retry.
+ */
+export function ErrorFallback({
+  error,
+  resetErrorBoundary,
+}: {
+  error: Error;
+  resetErrorBoundary: () => void;
+}) {
+  return (
+    <Dialog open>
+      <DialogContent className="text-center">
+        <DialogHeader>
+          <DialogTitle>Something went wrong</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-destructive">{error.message}</p>
+        <Button onClick={resetErrorBoundary} className="mt-4">
+          Try again
+        </Button>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- create ErrorFallback component using Shadcn Dialog and Button
- update Providers to use the new fallback component

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_68437f825a60832f971884933aa213ef