### PR TITLE
feat: add stop generation button to cancel AI streaming responses

### DIFF
--- a/components/Inputs/InputChat/index.tsx
+++ b/components/Inputs/InputChat/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Square } from "lucide-react";
 import { type FC, useState } from "react";
 import { IoMdSend } from "react-icons/io";
 import { Button } from "@/components/ui/button";
@@ -9,10 +10,11 @@ import { useConfig, useUIActions } from "@/store";
 
 interface InputChatProps {
   onSubmit: (message: string) => void;
+  onStop: () => void;
   isLoading: boolean;
 }
 
-export const InputChat: FC<InputChatProps> = ({ onSubmit, isLoading }) => {
+export const InputChat: FC<InputChatProps> = ({ onSubmit, onStop, isLoading }) => {
   const [message, setMessage] = useState("");
 
   const { hasValidApiKey } = useConfig();
@@ -56,18 +58,33 @@ export const InputChat: FC<InputChatProps> = ({ onSubmit, isLoading }) => {
           disabled={isLoading || !hasApiKey}
         />
         {hasApiKey ? (
-          <Button
-            size="icon"
-            className={cn(
-              "absolute right-2 h-10 w-10 rounded-lg",
-              "hover:opacity-90 transition-opacity"
-            )}
-            onClick={handleSendMessage}
-            disabled={isLoading || !message.trim()}
-            aria-label="Send message"
-          >
-            <IoMdSend className="h-4 w-4" />
-          </Button>
+          isLoading ? (
+            <Button
+              size="icon"
+              variant="destructive"
+              className={cn(
+                "absolute right-2 h-10 w-10 rounded-lg",
+                "hover:opacity-90 transition-opacity"
+              )}
+              onClick={onStop}
+              aria-label="Stop generating"
+            >
+              <Square className="h-4 w-4 fill-current" />
+            </Button>
+          ) : (
+            <Button
+              size="icon"
+              className={cn(
+                "absolute right-2 h-10 w-10 rounded-lg",
+                "hover:opacity-90 transition-opacity"
+              )}
+              onClick={handleSendMessage}
+              disabled={!message.trim()}
+              aria-label="Send message"
+            >
+              <IoMdSend className="h-4 w-4" />
+            </Button>
+          )
         ) : (
           <Button
             className={cn(

--- a/components/Inputs/InputChat/index.tsx
+++ b/components/Inputs/InputChat/index.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { Square } from "lucide-react";
+import { Send, Square } from "lucide-react";
 import { type FC, useState } from "react";
-import { IoMdSend } from "react-icons/io";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
@@ -82,7 +81,7 @@ export const InputChat: FC<InputChatProps> = ({ onSubmit, onStop, isLoading }) =
               disabled={!message.trim()}
               aria-label="Send message"
             >
-              <IoMdSend className="h-4 w-4" />
+              <Send className="h-4 w-4" />
             </Button>
           )
         ) : (

--- a/components/chat/ChatArea/index.tsx
+++ b/components/chat/ChatArea/index.tsx
@@ -20,7 +20,8 @@ export const ChatArea = () => {
   const { setSettingsModalOpen } = useUIActions();
   const { hasValidApiKey } = useConfig();
   const hasApiKey = hasValidApiKey();
-  const { sendMessage, isLoading, messages, isError, error } = useCircleChat();
+  const { sendMessage, stopGeneration, isLoading, messages, isError, error } =
+    useCircleChat();
   // TEMP: Disabled for rebuild - FCX-30
   // const [hasSession, setHasSession] = useState<boolean | null>(null);
 
@@ -114,7 +115,11 @@ export const ChatArea = () => {
       </div>
 
       <div className="w-full py-8">
-        <InputChat isLoading={isLoading} onSubmit={handleSubmit} />
+        <InputChat
+          isLoading={isLoading}
+          onSubmit={handleSubmit}
+          onStop={stopGeneration}
+        />
       </div>
     </div>
   );

--- a/hooks/useCircleChat.ts
+++ b/hooks/useCircleChat.ts
@@ -1,5 +1,5 @@
 import { useRouter } from "next/navigation";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useSendMessageStream } from "@/fetch/chat/mutations";
 import type { ChatMessage } from "@/lib/langchain/chatService";
@@ -17,6 +17,12 @@ export const useCircleChat = () => {
     useChatActions();
   const { accumulateChunk, flushChunks, flushIntervalRef } = useManageChunks();
   const sendMessageStream = useSendMessageStream();
+
+  useEffect(() => {
+    return () => {
+      abortControllerRef.current?.abort();
+    };
+  }, []);
 
   const sendMessage = (message: string) => {
     if (isSendingRef.current || isLoading) {
@@ -88,8 +94,7 @@ export const useCircleChat = () => {
         }
         flushChunks();
 
-        const isAborted =
-          error.name === "AbortError" || error.message?.includes("aborted");
+        const isAborted = error.name === "AbortError";
 
         if (isAborted) {
           if (!partialResponse || !partialResponse.trim()) {


### PR DESCRIPTION
Wire up AbortController through existing signal plumbing to allow users
to cancel in-progress AI responses. The send button becomes a stop
button during streaming, partial content is preserved on cancellation.

https://claude.ai/code/session_01XAcGBXXQw1F15RjDAL5dfW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to stop in-progress AI message generation. While the AI is generating a response, the send button is replaced with a stop button, allowing users to cancel the request. Once generation completes or is stopped, the send button returns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->