### PR TITLE
feat: add Google Gemini and Gemma 4 model support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "@hookform/resolvers": "^5.0.1",
         "@langchain/anthropic": "^1.3.26",
         "@langchain/core": "^1.1.40",
+        "@langchain/google-genai": "^2.1.27",
         "@langchain/openai": "^1.4.4",
         "@next/env": "16.0.10",
         "@radix-ui/react-checkbox": "^1.3.2",
@@ -305,6 +306,8 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
 
+    "@google/generative-ai": ["@google/generative-ai@0.24.1", "", {}, "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q=="],
+
     "@hookform/resolvers": ["@hookform/resolvers@5.2.2", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "react-hook-form": "^7.55.0" } }, "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA=="],
 
     "@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
@@ -376,6 +379,8 @@
     "@langchain/anthropic": ["@langchain/anthropic@1.3.26", "", { "dependencies": { "@anthropic-ai/sdk": "^0.74.0", "zod": "^3.25.76 || ^4" }, "peerDependencies": { "@langchain/core": "^1.1.38" } }, "sha512-8gfnM1MzZkb3HVD0WjWeb/HFdP4cNGWSokhBtrwW0qSJN+b1j9oBMwWZaVdd+VBKsx4hqzv0bdrMzWje0TMw+g=="],
 
     "@langchain/core": ["@langchain/core@1.1.40", "", { "dependencies": { "@cfworker/json-schema": "^4.0.2", "@standard-schema/spec": "^1.1.0", "ansi-styles": "^5.0.0", "camelcase": "6", "decamelize": "1.2.0", "js-tiktoken": "^1.0.12", "langsmith": ">=0.5.0 <1.0.0", "mustache": "^4.2.0", "p-queue": "^6.6.2", "uuid": "^11.1.0", "zod": "^3.25.76 || ^4" } }, "sha512-RJ41GQEMxr9ZEZNoIiPgW0+v9nAY6FEZGlk+MjBghr2GR8He50abLam0XCe1aqUJjuKbqt2lUD6M+6SZ+2NIJg=="],
+
+    "@langchain/google-genai": ["@langchain/google-genai@2.1.27", "", { "dependencies": { "@google/generative-ai": "^0.24.0", "uuid": "^11.1.0" }, "peerDependencies": { "@langchain/core": "^1.1.40" } }, "sha512-KCmSrOopY8dF7RweK6NpXU0qSJrrmTkv6aD4b2UJZ45jzyNwEW/tp8jQV6Ljc9e3C402fuNtjpiAjTi7KL0fZQ=="],
 
     "@langchain/langgraph": ["@langchain/langgraph@1.2.9", "", { "dependencies": { "@langchain/langgraph-checkpoint": "^1.0.1", "@langchain/langgraph-sdk": "~1.8.9", "@standard-schema/spec": "1.1.0", "uuid": "^10.0.0" }, "peerDependencies": { "@langchain/core": "^1.1.40", "zod": "^3.25.32 || ^4.2.0", "zod-to-json-schema": "^3.x" }, "optionalPeers": ["zod-to-json-schema"] }, "sha512-3c7BtGycHC2v9p6w/Hv8L7kEl1YnZYOQTDJtmAp3knk6JOedO7d2bYP3y0SRyhv5orUEGf/KGvx8ZsB/ideP7g=="],
 

--- a/components/modals/settings/index.tsx
+++ b/components/modals/settings/index.tsx
@@ -5,6 +5,7 @@ import { Cpu, Eye, EyeOff, KeyRound, LogOut, Settings2, SunMoon } from "lucide-r
 import { useTheme } from "next-themes";
 import * as React from "react";
 import { useState } from "react";
+import type { Control } from "react-hook-form";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
@@ -56,6 +57,63 @@ import { useConfig, useUserActions } from "@/store";
 import type { ModelType } from "@/store/types";
 import { createClient } from "@/utils/supabase/client";
 
+type ApiKeyFieldName = "openAIKey" | "anthropicKey" | "googleKey";
+
+type SettingsFormValues = {
+  openAIKey?: string;
+  anthropicKey?: string;
+  googleKey?: string;
+  selectedModel: string;
+  enabledModels: string[];
+};
+
+function ApiKeyField({
+  name,
+  label,
+  placeholder,
+  control,
+}: {
+  name: ApiKeyFieldName;
+  label: string;
+  placeholder: string;
+  control: Control<SettingsFormValues>;
+}) {
+  const [show, setShow] = useState(false);
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>{label}</FormLabel>
+          <FormControl>
+            <div className="relative">
+              <Input
+                {...field}
+                type={show ? "text" : "password"}
+                placeholder={placeholder}
+                className="pr-10"
+                autoComplete="off"
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="absolute right-0 top-0 h-full px-3 hover:bg-transparent"
+                aria-label={show ? `Hide ${label}` : `Show ${label}`}
+                onClick={() => setShow((s) => !s)}
+              >
+                {show ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </Button>
+            </div>
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}
+
 interface SettingsModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -97,12 +155,6 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
       enabledModels: (config.enabledModels || [...DEFAULT_ENABLED_MODELS]) as ModelType[],
     });
   }, [config, form]);
-
-  const [showPasswords, setShowPasswords] = useState({
-    openAI: false,
-    anthropic: false,
-    google: false,
-  });
 
   // eslint-disable-next-line react-hooks/incompatible-library
   const watchedValues = form.watch();
@@ -350,122 +402,23 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
                 Provide the API key for your selected model. Your keys are securely stored
                 in your browser.
               </p>
-              {/* OpenAI Key */}
-              <FormField
-                control={form.control}
+              <ApiKeyField
+                control={form.control as Control<SettingsFormValues>}
                 name="openAIKey"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>OpenAI API Key</FormLabel>
-                    <FormControl>
-                      <div className="relative">
-                        <Input
-                          {...field}
-                          type={showPasswords.openAI ? "text" : "password"}
-                          placeholder="sk-..."
-                          className="pr-10"
-                        />
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon"
-                          className="absolute right-0 top-0 h-full px-3 hover:bg-transparent"
-                          onClick={() =>
-                            setShowPasswords((prev) => ({
-                              ...prev,
-                              openAI: !prev.openAI,
-                            }))
-                          }
-                        >
-                          {showPasswords.openAI ? (
-                            <EyeOff className="h-4 w-4" />
-                          ) : (
-                            <Eye className="h-4 w-4" />
-                          )}
-                        </Button>
-                      </div>
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
+                label="OpenAI API Key"
+                placeholder="sk-..."
               />
-              {/* Anthropic Key */}
-              <FormField
-                control={form.control}
+              <ApiKeyField
+                control={form.control as Control<SettingsFormValues>}
                 name="anthropicKey"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Anthropic API Key</FormLabel>
-                    <FormControl>
-                      <div className="relative">
-                        <Input
-                          {...field}
-                          type={showPasswords.anthropic ? "text" : "password"}
-                          placeholder="sk-ant-..."
-                          className="pr-10"
-                        />
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon"
-                          className="absolute right-0 top-0 h-full px-3 hover:bg-transparent"
-                          onClick={() =>
-                            setShowPasswords((prev) => ({
-                              ...prev,
-                              anthropic: !prev.anthropic,
-                            }))
-                          }
-                        >
-                          {showPasswords.anthropic ? (
-                            <EyeOff className="h-4 w-4" />
-                          ) : (
-                            <Eye className="h-4 w-4" />
-                          )}
-                        </Button>
-                      </div>
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
+                label="Anthropic API Key"
+                placeholder="sk-ant-..."
               />
-              {/* Google Key */}
-              <FormField
-                control={form.control}
+              <ApiKeyField
+                control={form.control as Control<SettingsFormValues>}
                 name="googleKey"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Google API Key</FormLabel>
-                    <FormControl>
-                      <div className="relative">
-                        <Input
-                          {...field}
-                          type={showPasswords.google ? "text" : "password"}
-                          placeholder="AIza..."
-                          className="pr-10"
-                        />
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon"
-                          className="absolute right-0 top-0 h-full px-3 hover:bg-transparent"
-                          onClick={() =>
-                            setShowPasswords((prev) => ({
-                              ...prev,
-                              google: !prev.google,
-                            }))
-                          }
-                        >
-                          {showPasswords.google ? (
-                            <EyeOff className="h-4 w-4" />
-                          ) : (
-                            <Eye className="h-4 w-4" />
-                          )}
-                        </Button>
-                      </div>
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
+                label="Google API Key"
+                placeholder="AIza..."
               />
               <div>
                 <Button type="submit" className="w-full">

--- a/components/modals/settings/index.tsx
+++ b/components/modals/settings/index.tsx
@@ -64,6 +64,7 @@ interface SettingsModalProps {
 const settingsFormSchema = z.object({
   openAIKey: z.string().optional(),
   anthropicKey: z.string().optional(),
+  googleKey: z.string().optional(),
   selectedModel: z.enum(MODEL_VALUES),
   enabledModels: z
     .array(z.enum(MODEL_VALUES))
@@ -81,6 +82,7 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
     defaultValues: {
       openAIKey: config.openAIKey || "",
       anthropicKey: config.anthropicKey || "",
+      googleKey: config.googleKey || "",
       selectedModel: (config.selectedModel || DEFAULT_MODEL) as ModelType,
       enabledModels: (config.enabledModels || [...DEFAULT_ENABLED_MODELS]) as ModelType[],
     },
@@ -90,6 +92,7 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
     form.reset({
       openAIKey: config.openAIKey || "",
       anthropicKey: config.anthropicKey || "",
+      googleKey: config.googleKey || "",
       selectedModel: (config.selectedModel || DEFAULT_MODEL) as ModelType,
       enabledModels: (config.enabledModels || [...DEFAULT_ENABLED_MODELS]) as ModelType[],
     });
@@ -98,6 +101,7 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
   const [showPasswords, setShowPasswords] = useState({
     openAI: false,
     anthropic: false,
+    google: false,
   });
 
   // eslint-disable-next-line react-hooks/incompatible-library
@@ -108,6 +112,7 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
     enabledModels: watchedValues.enabledModels,
     openAIKey: watchedValues.openAIKey,
     anthropicKey: watchedValues.anthropicKey,
+    googleKey: watchedValues.googleKey,
   });
 
   React.useEffect(() => {
@@ -171,6 +176,7 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
     setConfig({
       openAIKey: data.openAIKey || "",
       anthropicKey: data.anthropicKey || "",
+      googleKey: data.googleKey || "",
       selectedModel: data.selectedModel as ModelType,
       enabledModels: data.enabledModels as ModelType[],
     });
@@ -180,11 +186,14 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
 
   // Prepare options for the multiple combobox
   const modelOptions: MultipleComboboxOption[] = MODEL_OPTIONS.map((option) => {
-    const hasRequiredKey = hasRequiredKeyForModel(option.value, watchedValues);
+    const hasRequiredKey = hasRequiredKeyForModel(option.value, {
+      openAIKey: watchedValues.openAIKey,
+      anthropicKey: watchedValues.anthropicKey,
+      googleKey: watchedValues.googleKey,
+    });
     return {
       value: option.value,
       label: option.label,
-      description: option.description,
       badge: option.provider,
       disabled: !hasRequiredKey,
     };
@@ -408,6 +417,45 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
                           }
                         >
                           {showPasswords.anthropic ? (
+                            <EyeOff className="h-4 w-4" />
+                          ) : (
+                            <Eye className="h-4 w-4" />
+                          )}
+                        </Button>
+                      </div>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              {/* Google Key */}
+              <FormField
+                control={form.control}
+                name="googleKey"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Google API Key</FormLabel>
+                    <FormControl>
+                      <div className="relative">
+                        <Input
+                          {...field}
+                          type={showPasswords.google ? "text" : "password"}
+                          placeholder="AIza..."
+                          className="pr-10"
+                        />
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className="absolute right-0 top-0 h-full px-3 hover:bg-transparent"
+                          onClick={() =>
+                            setShowPasswords((prev) => ({
+                              ...prev,
+                              google: !prev.google,
+                            }))
+                          }
+                        >
+                          {showPasswords.google ? (
                             <EyeOff className="h-4 w-4" />
                           ) : (
                             <Eye className="h-4 w-4" />

--- a/constants/models.ts
+++ b/constants/models.ts
@@ -18,7 +18,6 @@ export interface ModelDefinition {
   label: string;
   provider: ModelProvider;
   requiresKey: ApiKeyType;
-  description: string;
   reasoning: ModelReasoning;
 }
 
@@ -28,7 +27,6 @@ export const MODEL_OPTIONS = [
     label: "Claude Opus 4.7",
     provider: "Anthropic",
     requiresKey: "anthropicKey",
-    description: "Most capable model for complex reasoning and agentic coding",
     reasoning: {
       configurable: true,
       supportsTemperature: true,
@@ -41,7 +39,6 @@ export const MODEL_OPTIONS = [
     label: "Claude Sonnet 4.6",
     provider: "Anthropic",
     requiresKey: "anthropicKey",
-    description: "Best balance of speed and intelligence",
     reasoning: {
       configurable: true,
       supportsTemperature: true,
@@ -54,7 +51,6 @@ export const MODEL_OPTIONS = [
     label: "Claude Haiku 4.5",
     provider: "Anthropic",
     requiresKey: "anthropicKey",
-    description: "Fastest Claude model with near-frontier intelligence",
     reasoning: {
       configurable: true,
       supportsTemperature: true,
@@ -67,7 +63,6 @@ export const MODEL_OPTIONS = [
     label: "GPT-5.4",
     provider: "OpenAI",
     requiresKey: "openAIKey",
-    description: "Frontier model for complex professional work",
     reasoning: {
       configurable: true,
       supportsTemperature: true,
@@ -80,7 +75,6 @@ export const MODEL_OPTIONS = [
     label: "GPT-5.4 Mini",
     provider: "OpenAI",
     requiresKey: "openAIKey",
-    description: "Balanced speed and intelligence for high-volume workloads",
     reasoning: {
       configurable: true,
       supportsTemperature: true,
@@ -93,7 +87,54 @@ export const MODEL_OPTIONS = [
     label: "GPT-5.4 Nano",
     provider: "OpenAI",
     requiresKey: "openAIKey",
-    description: "Fastest GPT model for classification and extraction",
+    reasoning: {
+      configurable: true,
+      supportsTemperature: true,
+      defaultLevel: "none",
+      levels: ["none", "low", "medium", "high", "max"],
+    },
+  },
+  {
+    value: "gemma-4-31b-it",
+    label: "Gemma 4 31B",
+    provider: "Google",
+    requiresKey: "googleKey",
+    reasoning: {
+      configurable: true,
+      supportsTemperature: true,
+      defaultLevel: "none",
+      levels: ["none", "high"],
+    },
+  },
+  {
+    value: "gemma-4-26b-a4b-it",
+    label: "Gemma 4 26B",
+    provider: "Google",
+    requiresKey: "googleKey",
+    reasoning: {
+      configurable: true,
+      supportsTemperature: true,
+      defaultLevel: "none",
+      levels: ["none", "high"],
+    },
+  },
+  {
+    value: "gemini-3-flash-preview",
+    label: "Gemini 3 Flash",
+    provider: "Google",
+    requiresKey: "googleKey",
+    reasoning: {
+      configurable: true,
+      supportsTemperature: true,
+      defaultLevel: "none",
+      levels: ["none", "low", "medium", "high", "max"],
+    },
+  },
+  {
+    value: "gemini-3.1-flash-lite-preview",
+    label: "Gemini 3.1 Flash Lite",
+    provider: "Google",
+    requiresKey: "googleKey",
     reasoning: {
       configurable: true,
       supportsTemperature: true,
@@ -141,7 +182,16 @@ type OpenAIReasoningFields = {
   reasoning?: { effort: OpenAIReasoningEffort };
 };
 
-export type ReasoningFields = AnthropicReasoningFields | OpenAIReasoningFields;
+type GoogleThinkingLevel = "LOW" | "MEDIUM" | "HIGH";
+
+type GoogleReasoningFields = {
+  thinkingConfig?: { thinkingLevel: GoogleThinkingLevel };
+};
+
+export type ReasoningFields =
+  | AnthropicReasoningFields
+  | OpenAIReasoningFields
+  | GoogleReasoningFields;
 
 const ANTHROPIC_ADAPTIVE_MODELS = new Set<string>([
   "claude-opus-4-7",
@@ -171,6 +221,14 @@ const OPENAI_REASONING_EFFORTS: Record<ReasoningLevel, OpenAIReasoningEffort> = 
   medium: "medium",
   high: "high",
   max: "xhigh",
+};
+
+const GOOGLE_THINKING_LEVELS: Record<ReasoningLevel, GoogleThinkingLevel | null> = {
+  none: null,
+  low: "LOW",
+  medium: "MEDIUM",
+  high: "HIGH",
+  max: "HIGH",
 };
 
 function getAnthropicReasoningFields(
@@ -205,6 +263,12 @@ export function getReasoningFields(
 
   if (model.provider === "OpenAI") {
     return { reasoning: { effort: OPENAI_REASONING_EFFORTS[level] } };
+  }
+
+  if (model.provider === "Google") {
+    const thinkingLevel = GOOGLE_THINKING_LEVELS[level];
+    if (!thinkingLevel) return {};
+    return { thinkingConfig: { thinkingLevel } };
   }
 
   return {};

--- a/hooks/useCircleChat.ts
+++ b/hooks/useCircleChat.ts
@@ -78,6 +78,7 @@ export const useCircleChat = () => {
       config: {
         openAIKey: config.openAIKey,
         anthropicKey: config.anthropicKey,
+        googleKey: config.googleKey,
         selectedModel: config.selectedModel,
         reasoningLevel: config.reasoningLevel,
       },

--- a/lib/chat/config.ts
+++ b/lib/chat/config.ts
@@ -17,14 +17,16 @@ function hasValue(value?: string): boolean {
   return Boolean(value?.trim());
 }
 
-function isSupportedApiKey(
-  key: ApiKeyType | null
-): key is Exclude<ApiKeyType, "googleKey"> {
-  return key === "openAIKey" || key === "anthropicKey";
+function isSupportedApiKey(key: ApiKeyType | null): key is ApiKeyType {
+  return key === "openAIKey" || key === "anthropicKey" || key === "googleKey";
 }
 
 export function hasAnyApiKey(config: ChatApiKeys): boolean {
-  return hasValue(config.openAIKey) || hasValue(config.anthropicKey);
+  return (
+    hasValue(config.openAIKey) ||
+    hasValue(config.anthropicKey) ||
+    hasValue(config.googleKey)
+  );
 }
 
 export function getRequiredApiKey(modelValue: string): ApiKeyType | null {
@@ -75,10 +77,6 @@ export function getSelectedModelError(
   const modelConfig = getModelConfig(config.selectedModel);
   if (!modelConfig) {
     return "Selected model is not available.";
-  }
-
-  if (modelConfig.provider === "Google") {
-    return "Google Gemini support is not yet implemented.";
   }
 
   if (hasRequiredKeyForModel(config.selectedModel, config)) {

--- a/lib/chat/contracts.ts
+++ b/lib/chat/contracts.ts
@@ -20,6 +20,7 @@ export type ChatMessage = z.infer<typeof ChatMessageSchema>;
 export const ChatModelConfigSchema = z.object({
   openAIKey: z.string().optional(),
   anthropicKey: z.string().optional(),
+  googleKey: z.string().optional(),
   selectedModel: z.enum(MODEL_VALUES),
   reasoningLevel: z.enum(REASONING_LEVELS).optional(),
   maxTokens: z.number().int().positive().optional(),
@@ -29,7 +30,10 @@ export const ChatModelConfigSchema = z.object({
 });
 
 export type ChatModelConfig = z.infer<typeof ChatModelConfigSchema>;
-export type ChatApiKeys = Pick<ChatModelConfig, "openAIKey" | "anthropicKey">;
+export type ChatApiKeys = Pick<
+  ChatModelConfig,
+  "openAIKey" | "anthropicKey" | "googleKey"
+>;
 export type ChatModelSelection = {
   selectedModel?: ModelValue;
   enabledModels?: readonly ModelValue[];

--- a/lib/langchain/chatService.ts
+++ b/lib/langchain/chatService.ts
@@ -15,9 +15,10 @@ const DEFAULT_TIMEOUT_MS = 120_000;
 const DEFAULT_MAX_RETRIES = 2;
 const DEFAULT_TEMPERATURE = 0.7;
 
-const PROVIDER_PREFIX: Record<"OpenAI" | "Anthropic", string> = {
+const PROVIDER_PREFIX: Record<"OpenAI" | "Anthropic" | "Google", string> = {
   OpenAI: "openai",
   Anthropic: "anthropic",
+  Google: "google-genai",
 };
 
 export interface StreamChatResponseOptions {
@@ -36,18 +37,20 @@ async function buildChatModel(
     throw new Error(`Unknown model: ${config.selectedModel}`);
   }
 
-  if (modelConfig.provider === "Google") {
-    throw new Error("Google Gemini support is not yet implemented.");
-  }
-
   const apiKey =
-    modelConfig.provider === "Anthropic" ? config.anthropicKey : config.openAIKey;
+    modelConfig.provider === "Anthropic"
+      ? config.anthropicKey
+      : modelConfig.provider === "Google"
+        ? config.googleKey
+        : config.openAIKey;
   if (!apiKey) {
-    throw new Error(
+    const providerName =
       modelConfig.provider === "Anthropic"
-        ? "Anthropic API key is required for Claude models."
-        : "OpenAI API key is required for OpenAI models."
-    );
+        ? "Anthropic"
+        : modelConfig.provider === "Google"
+          ? "Google"
+          : "OpenAI";
+    throw new Error(`${providerName} API key is required for ${modelConfig.label}.`);
   }
 
   const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;

--- a/lib/langchain/chatService.ts
+++ b/lib/langchain/chatService.ts
@@ -1,12 +1,13 @@
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { AIMessage, HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { initChatModel } from "langchain";
+import type { ModelProvider } from "@/constants/models";
 import {
   getModelConfig,
   getReasoningFields,
   supportsTemperatureAtLevel,
 } from "@/constants/models";
-import type { ChatMessage, ChatModelConfig } from "@/lib/chat/contracts";
+import type { ChatApiKeys, ChatMessage, ChatModelConfig } from "@/lib/chat/contracts";
 
 export const DEFAULT_SYSTEM_PROMPT =
   "You are EnkiAI, a helpful and knowledgeable AI assistant.";
@@ -37,20 +38,16 @@ async function buildChatModel(
     throw new Error(`Unknown model: ${config.selectedModel}`);
   }
 
-  const apiKey =
-    modelConfig.provider === "Anthropic"
-      ? config.anthropicKey
-      : modelConfig.provider === "Google"
-        ? config.googleKey
-        : config.openAIKey;
+  const PROVIDER_KEY: Record<ModelProvider, keyof ChatApiKeys> = {
+    OpenAI: "openAIKey",
+    Anthropic: "anthropicKey",
+    Google: "googleKey",
+  };
+  const apiKey = config[PROVIDER_KEY[modelConfig.provider]];
   if (!apiKey) {
-    const providerName =
-      modelConfig.provider === "Anthropic"
-        ? "Anthropic"
-        : modelConfig.provider === "Google"
-          ? "Google"
-          : "OpenAI";
-    throw new Error(`${providerName} API key is required for ${modelConfig.label}.`);
+    throw new Error(
+      `${modelConfig.provider} API key is required for ${modelConfig.label}.`
+    );
   }
 
   const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@hookform/resolvers": "^5.0.1",
     "@langchain/anthropic": "^1.3.26",
     "@langchain/core": "^1.1.40",
+    "@langchain/google-genai": "^2.1.27",
     "@langchain/openai": "^1.4.4",
     "@next/env": "16.0.10",
     "@radix-ui/react-checkbox": "^1.3.2",

--- a/store/index.ts
+++ b/store/index.ts
@@ -23,7 +23,7 @@ export const useStore = create<StoreState>()(
       }),
       {
         name: "chat-store",
-        version: 3,
+        version: 4,
         migrate: (persistedState, version) => {
           const state = persistedState as { config?: Partial<Config> } | undefined;
           if (version < 2 && state?.config && state.config.reasoningLevel === undefined) {
@@ -48,6 +48,9 @@ export const useStore = create<StoreState>()(
               state.config.enabledModels =
                 filtered.length > 0 ? filtered : [...DEFAULT_ENABLED_MODELS];
             }
+          }
+          if (version < 4 && state?.config && state.config.googleKey === undefined) {
+            state.config.googleKey = "";
           }
           return state;
         },

--- a/store/slices/configSlice.ts
+++ b/store/slices/configSlice.ts
@@ -15,6 +15,7 @@ export interface ConfigSlice {
 const initialConfig: Config = {
   openAIKey: "",
   anthropicKey: "",
+  googleKey: "",
   selectedModel: DEFAULT_MODEL,
   enabledModels: [...DEFAULT_ENABLED_MODELS],
   reasoningLevel: getModelConfig(DEFAULT_MODEL)?.reasoning.defaultLevel ?? "none",


### PR DESCRIPTION
## Summary

- Add 4 Google models: Gemma 4 31B, Gemma 4 26B, Gemini 3 Flash, Gemini 3.1 Flash Lite
- Wire `googleKey` end-to-end through contracts, config helpers, chat service, store, and settings UI
- Add Google thinking/reasoning support (`thinkingConfig` via `@langchain/google-genai`)
- Drop `description` field from `ModelDefinition` and all model entries

## Reasoning capabilities

| Model | Thinking levels |
|---|---|
| Gemma 4 31B | `none` / `high` (on/off only) |
| Gemma 4 26B | `none` / `high` (on/off only) |
| Gemini 3 Flash | `none` / `low` / `medium` / `high` / `max` |
| Gemini 3.1 Flash Lite | `none` / `low` / `medium` / `high` / `max` |

## Test plan

- [ ] Enter a Google API key in Settings and enable a Google model
- [ ] Send a message using Gemma 4 31B / 26B
- [ ] Send a message using Gemini 3 Flash / 3.1 Flash Lite
- [ ] Toggle reasoning level on Gemini models and verify it changes behavior
- [ ] Verify existing OpenAI and Anthropic models still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google API Key configuration field in settings with secure show/hide toggle
  * Google-backed AI models now available for selection
  * Reasoning level configuration support added for Google models

<!-- end of auto-generated comment: release notes by coderabbit.ai -->