### PR TITLE
feat(chat): tiered local AI model strategy for guest users

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,4 +1,5 @@
 import type { NextRequest } from "next/server";
+import { isLocalModel } from "@/constants/models";
 import { getSelectedModelError } from "@/lib/chat/config";
 import { ChatStreamRequestSchema } from "@/lib/chat/contracts";
 import { streamChatResponse } from "@/lib/langchain/chatService";
@@ -21,6 +22,12 @@ export async function POST(req: NextRequest) {
   }
 
   const request = parsedBody.data;
+  if (isLocalModel(request.config.selectedModel)) {
+    return jsonError(
+      "Local models run in the browser and cannot be called through this endpoint.",
+      400
+    );
+  }
   const selectedModelError = getSelectedModelError(request.config);
   if (selectedModelError) {
     return jsonError(selectedModelError, 400);

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@hookform/resolvers": "^5.0.1",
+        "@huggingface/transformers": "^4.1.0",
         "@langchain/anthropic": "^1.3.26",
         "@langchain/core": "^1.1.40",
         "@langchain/google-genai": "^2.1.27",
@@ -310,6 +311,12 @@
 
     "@hookform/resolvers": ["@hookform/resolvers@5.2.2", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "react-hook-form": "^7.55.0" } }, "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA=="],
 
+    "@huggingface/jinja": ["@huggingface/jinja@0.5.7", "", {}, "sha512-OosMEbF/R6zkKNNzqhI7kvKYCpo1F0UeIv46/h4D4UjVEKKd6k3TiV8sgu6fkreX4lbBiRI+lZG8UnXnqVQmEQ=="],
+
+    "@huggingface/tokenizers": ["@huggingface/tokenizers@0.1.3", "", {}, "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA=="],
+
+    "@huggingface/transformers": ["@huggingface/transformers@4.1.0", "", { "dependencies": { "@huggingface/jinja": "^0.5.6", "@huggingface/tokenizers": "^0.1.3", "onnxruntime-node": "1.24.3", "onnxruntime-web": "1.26.0-dev.20260410-5e55544225", "sharp": "^0.34.5" } }, "sha512-WiMf9eyvF6V2pj4gs12A7GQV3svyFIBtB/W+Hn5lT5E5DyqWUno1ZrWoAfJv69X1RNv/0GoOo6DFmL6NOYd+rg=="],
+
     "@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
 
     "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
@@ -417,6 +424,26 @@
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
     "@popperjs/core": ["@popperjs/core@2.11.8", "", {}, "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.4", "", {}, "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.0", "", {}, "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1", "@protobufjs/inquire": "^1.1.0" } }, "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.0", "", {}, "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
@@ -774,6 +801,8 @@
 
     "acorn-walk": ["acorn-walk@8.3.4", "", { "dependencies": { "acorn": "^8.11.0" } }, "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g=="],
 
+    "adm-zip": ["adm-zip@0.5.17", "", {}, "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ=="],
+
     "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
     "ansi-escapes": ["ansi-escapes@7.2.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw=="],
@@ -811,6 +840,8 @@
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.19", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g=="],
+
+    "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
 
     "brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
@@ -922,11 +953,17 @@
 
     "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
 
+    "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
+
     "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
+
+    "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
 
@@ -960,7 +997,13 @@
 
     "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "es6-error": ["es6-error@4.1.1", "", {}, "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="],
 
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
@@ -1002,6 +1045,8 @@
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
+    "flatbuffers": ["flatbuffers@25.9.23", "", {}, "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ=="],
+
     "focus-lock": ["focus-lock@1.3.6", "", { "dependencies": { "tslib": "^2.0.3" } }, "sha512-Ik/6OCk9RQQ0T5Xw+hKNLWrjSMtv51dD4GRmJjbD5a58TIEpI5a5iXagKVl3Z5UuyslMCA8Xwnu76jQob62Yhg=="],
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
@@ -1036,15 +1081,25 @@
 
     "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
+    "global-agent": ["global-agent@3.0.0", "", { "dependencies": { "boolean": "^3.0.1", "es6-error": "^4.1.1", "matcher": "^3.0.0", "roarr": "^2.15.3", "semver": "^7.3.2", "serialize-error": "^7.0.1" } }, "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q=="],
+
     "global-dirs": ["global-dirs@0.1.1", "", { "dependencies": { "ini": "^1.3.4" } }, "sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg=="],
+
+    "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
 
     "globrex": ["globrex@0.1.2", "", {}, "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="],
 
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "guid-typescript": ["guid-typescript@1.0.9", "", {}, "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ=="],
 
     "hard-rejection": ["hard-rejection@2.1.0", "", {}, "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
@@ -1146,6 +1201,8 @@
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
+    "json-stringify-safe": ["json-stringify-safe@5.0.1", "", {}, "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="],
+
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
@@ -1216,6 +1273,8 @@
 
     "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
 
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
@@ -1241,6 +1300,8 @@
     "map-obj": ["map-obj@4.3.0", "", {}, "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="],
 
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
+    "matcher": ["matcher@3.0.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0" } }, "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng=="],
 
     "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
 
@@ -1378,7 +1439,15 @@
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
+    "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
+
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
+
+    "onnxruntime-common": ["onnxruntime-common@1.24.3", "", {}, "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA=="],
+
+    "onnxruntime-node": ["onnxruntime-node@1.24.3", "", { "dependencies": { "adm-zip": "^0.5.16", "global-agent": "^3.0.0", "onnxruntime-common": "1.24.3" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg=="],
+
+    "onnxruntime-web": ["onnxruntime-web@1.26.0-dev.20260410-5e55544225", "", { "dependencies": { "flatbuffers": "^25.1.24", "guid-typescript": "^1.0.9", "long": "^5.2.3", "onnxruntime-common": "1.24.0-dev.20251116-b39e144322", "platform": "^1.3.6", "protobufjs": "^7.2.4" } }, "sha512-hHd9n8DzIfGSAjM4Dvslesc8i6h9HEEcl8qt7X3LfhUxMgls6FBJ32j2xrDtJjKJFEehFeJmyB/pvad1I8KS8w=="],
 
     "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
@@ -1426,6 +1495,8 @@
 
     "pidtree": ["pidtree@0.6.0", "", { "bin": { "pidtree": "bin/pidtree.js" } }, "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g=="],
 
+    "platform": ["platform@1.3.6", "", {}, "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="],
+
     "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
 
     "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
@@ -1443,6 +1514,8 @@
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
+    "protobufjs": ["protobufjs@7.5.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg=="],
 
     "quick-lru": ["quick-lru@4.0.1", "", {}, "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="],
 
@@ -1516,6 +1589,8 @@
 
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
+    "roarr": ["roarr@2.15.4", "", { "dependencies": { "boolean": "^3.0.1", "detect-node": "^2.0.4", "globalthis": "^1.0.1", "json-stringify-safe": "^5.0.1", "semver-compare": "^1.0.0", "sprintf-js": "^1.1.2" } }, "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A=="],
+
     "rollup": ["rollup@4.53.3", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.53.3", "@rollup/rollup-android-arm64": "4.53.3", "@rollup/rollup-darwin-arm64": "4.53.3", "@rollup/rollup-darwin-x64": "4.53.3", "@rollup/rollup-freebsd-arm64": "4.53.3", "@rollup/rollup-freebsd-x64": "4.53.3", "@rollup/rollup-linux-arm-gnueabihf": "4.53.3", "@rollup/rollup-linux-arm-musleabihf": "4.53.3", "@rollup/rollup-linux-arm64-gnu": "4.53.3", "@rollup/rollup-linux-arm64-musl": "4.53.3", "@rollup/rollup-linux-loong64-gnu": "4.53.3", "@rollup/rollup-linux-ppc64-gnu": "4.53.3", "@rollup/rollup-linux-riscv64-gnu": "4.53.3", "@rollup/rollup-linux-riscv64-musl": "4.53.3", "@rollup/rollup-linux-s390x-gnu": "4.53.3", "@rollup/rollup-linux-x64-gnu": "4.53.3", "@rollup/rollup-linux-x64-musl": "4.53.3", "@rollup/rollup-openharmony-arm64": "4.53.3", "@rollup/rollup-win32-arm64-msvc": "4.53.3", "@rollup/rollup-win32-ia32-msvc": "4.53.3", "@rollup/rollup-win32-x64-gnu": "4.53.3", "@rollup/rollup-win32-x64-msvc": "4.53.3", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA=="],
 
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
@@ -1525,6 +1600,10 @@
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "semver-compare": ["semver-compare@1.0.0", "", {}, "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="],
+
+    "serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
 
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
@@ -1559,6 +1638,8 @@
     "spdx-license-ids": ["spdx-license-ids@3.0.22", "", {}, "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ=="],
 
     "split2": ["split2@3.2.2", "", { "dependencies": { "readable-stream": "^3.0.0" } }, "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg=="],
+
+    "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
@@ -1886,6 +1967,8 @@
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
+    "onnxruntime-web/onnxruntime-common": ["onnxruntime-common@1.24.0-dev.20251116-b39e144322", "", {}, "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw=="],
+
     "p-queue/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
@@ -1917,6 +2000,8 @@
     "restore-cursor/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "serialize-error/type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
 
     "slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 

--- a/components/Inputs/InputChat/index.tsx
+++ b/components/Inputs/InputChat/index.tsx
@@ -49,7 +49,7 @@ export const InputChat: FC<InputChatProps> = ({ onSubmit, onStop, isLoading }) =
             "min-h-[56px] w-full rounded-xl py-8 pl-4 text-base backdrop-blur-lg bg-background/50",
             canSend ? "pr-14" : "pr-24"
           )}
-          placeholder={canSend ? "Message EnkiAI..." : disabledPlaceholder}
+          placeholder={canSend ? "Ask anything" : disabledPlaceholder}
           value={message}
           onChange={(e) => setMessage(e.target.value)}
           onKeyDown={handleKeyPress}
@@ -59,7 +59,6 @@ export const InputChat: FC<InputChatProps> = ({ onSubmit, onStop, isLoading }) =
           isLoading ? (
             <Button
               size="icon"
-              variant="destructive"
               className={cn(
                 "absolute right-2 h-10 w-10 rounded-lg",
                 "hover:opacity-90 transition-opacity"

--- a/components/chat/ChatArea/index.tsx
+++ b/components/chat/ChatArea/index.tsx
@@ -9,9 +9,12 @@ import { Thread } from "@/components/chat/Thread";
 import { InputChat } from "@/components/Inputs/InputChat";
 // TEMP: Disabled for rebuild - FCX-30
 // import { ModalLogin } from "@/components/Modals/ChakraModals/Login";
+import { LocalModelConsentDialog } from "@/components/modals/local-model-consent";
+import { isLocalModel } from "@/constants/models";
 import { colors } from "@/constants/systemDesign/colors";
 import { useChatScroll } from "@/hooks/useChatScroll";
 import { useCircleChat } from "@/hooks/useCircleChat";
+import { useLocalModelConsent } from "@/hooks/useLocalModelConsent";
 import { canSendSelectedModel, getSelectedModelError } from "@/lib/chat/config";
 import { useConfig, useUIActions } from "@/store";
 
@@ -23,6 +26,7 @@ export const ChatArea = () => {
   const canSend = canSendSelectedModel(config);
   const { sendMessage, stopGeneration, isLoading, messages, isError, error } =
     useCircleChat();
+  const consent = useLocalModelConsent();
   // TEMP: Disabled for rebuild - FCX-30
   // const [hasSession, setHasSession] = useState<boolean | null>(null);
 
@@ -67,6 +71,11 @@ export const ChatArea = () => {
       );
       setSettingsModalOpen(true);
       return;
+    }
+
+    if (isLocalModel(config.selectedModel)) {
+      const confirmed = await consent.requestConsent();
+      if (!confirmed) return;
     }
 
     sendMessage(message);
@@ -125,6 +134,17 @@ export const ChatArea = () => {
           onStop={stopGeneration}
         />
       </div>
+
+      <LocalModelConsentDialog
+        open={consent.open}
+        spec={consent.spec}
+        onConfirm={consent.confirm}
+        onCancel={consent.cancel}
+        onAddApiKey={() => {
+          consent.cancel();
+          setSettingsModalOpen(true);
+        }}
+      />
     </div>
   );
 };

--- a/components/chat/ChatArea/index.tsx
+++ b/components/chat/ChatArea/index.tsx
@@ -74,8 +74,11 @@ export const ChatArea = () => {
     }
 
     if (isLocalModel(config.selectedModel)) {
-      const confirmed = await consent.requestConsent();
-      if (!confirmed) return;
+      const spec = await consent.requestConsent();
+      if (!spec) return;
+      sendMessage(message, spec);
+      scheduleScrollToBottom("smooth");
+      return;
     }
 
     sendMessage(message);

--- a/components/chat/ChatArea/index.tsx
+++ b/components/chat/ChatArea/index.tsx
@@ -6,9 +6,9 @@ import { useEffect, useState } from "react";
 import { toast } from "sonner";
 // import { hasActiveSession } from "@/utils/supabase/session";
 import { Thread } from "@/components/chat/Thread";
-import { InputChat } from "@/components/Inputs/InputChat";
 // TEMP: Disabled for rebuild - FCX-30
 // import { ModalLogin } from "@/components/Modals/ChakraModals/Login";
+import { InputChat } from "@/components/Inputs/InputChat";
 import { LocalModelConsentDialog } from "@/components/modals/local-model-consent";
 import { isLocalModel } from "@/constants/models";
 import { colors } from "@/constants/systemDesign/colors";

--- a/components/chat/ChatArea/index.tsx
+++ b/components/chat/ChatArea/index.tsx
@@ -24,8 +24,16 @@ export const ChatArea = () => {
   const { setSettingsModalOpen } = useUIActions();
   const { config } = useConfig();
   const canSend = canSendSelectedModel(config);
-  const { sendMessage, stopGeneration, isLoading, messages, isError, error } =
-    useCircleChat();
+  const {
+    sendMessage,
+    stopGeneration,
+    isLoading,
+    messages,
+    isError,
+    error,
+    localModelStatus,
+    localModelSpec,
+  } = useCircleChat();
   const consent = useLocalModelConsent();
   // TEMP: Disabled for rebuild - FCX-30
   // const [hasSession, setHasSession] = useState<boolean | null>(null);
@@ -44,6 +52,30 @@ export const ChatArea = () => {
     followKey,
     isLoading,
   });
+
+  useEffect(() => {
+    if (!localModelSpec) return;
+
+    const LOCAL_DOWNLOAD_TOAST_ID = "local-model-download";
+    const sizeLabel =
+      localModelSpec.approximateSizeMB >= 1000
+        ? `~${(localModelSpec.approximateSizeMB / 1000).toFixed(1)} GB`
+        : `~${localModelSpec.approximateSizeMB} MB`;
+
+    if (localModelStatus === "downloading") {
+      toast.loading(`Downloading ${localModelSpec.label} (${sizeLabel})…`, {
+        id: LOCAL_DOWNLOAD_TOAST_ID,
+        description: "First-run only. The model is cached for future messages.",
+      });
+    } else if (localModelStatus === "loading-cache") {
+      toast.loading(`Loading ${localModelSpec.label} from cache…`, {
+        id: LOCAL_DOWNLOAD_TOAST_ID,
+        description: "Warming up the local model.",
+      });
+    } else if (localModelStatus === "ready" || localModelStatus === "idle") {
+      toast.dismiss(LOCAL_DOWNLOAD_TOAST_ID);
+    }
+  }, [localModelStatus, localModelSpec]);
 
   useEffect(() => {
     if (isError && error?.message?.includes("API key")) {

--- a/components/modals/local-model-consent/index.tsx
+++ b/components/modals/local-model-consent/index.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { Download, KeyRound } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import type { LocalModelSpec } from "@/lib/local/capabilities";
+
+interface LocalModelConsentDialogProps {
+  open: boolean;
+  spec: LocalModelSpec | null;
+  onConfirm: () => void;
+  onCancel: () => void;
+  onAddApiKey: () => void;
+}
+
+export function LocalModelConsentDialog({
+  open,
+  spec,
+  onConfirm,
+  onCancel,
+  onAddApiKey,
+}: LocalModelConsentDialogProps) {
+  if (!spec) return null;
+
+  const sizeLabel =
+    spec.approximateSizeMB >= 1000
+      ? `~${(spec.approximateSizeMB / 1000).toFixed(1)} GB`
+      : `~${spec.approximateSizeMB} MB`;
+
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) onCancel();
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle className="flex items-center gap-2">
+            <Download className="h-5 w-5" />
+            Download AI model?
+          </AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="space-y-2">
+              <p>
+                <strong className="text-foreground">{spec.label}</strong> ({sizeLabel})
+                will be downloaded to your browser to run locally — no API key required.
+              </p>
+              <p>This is a one-time download and will be cached for future sessions.</p>
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter className="sm:justify-center">
+          <AlertDialogCancel onClick={onAddApiKey} className="gap-2">
+            <KeyRound className="h-4 w-4" />
+            Add API key instead
+          </AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm} className="gap-2">
+            <Download className="h-4 w-4" />
+            Download & continue
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/components/modals/local-model-consent/index.tsx
+++ b/components/modals/local-model-consent/index.tsx
@@ -59,11 +59,23 @@ export function LocalModelConsentDialog({
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter className="sm:justify-center">
-          <AlertDialogCancel onClick={onAddApiKey} className="gap-2">
+          <AlertDialogCancel
+            onClick={(e) => {
+              e.preventDefault();
+              onAddApiKey();
+            }}
+            className="gap-2"
+          >
             <KeyRound className="h-4 w-4" />
             Add API key instead
           </AlertDialogCancel>
-          <AlertDialogAction onClick={onConfirm} className="gap-2">
+          <AlertDialogAction
+            onClick={(e) => {
+              e.preventDefault();
+              onConfirm();
+            }}
+            className="gap-2"
+          >
             <Download className="h-4 w-4" />
             Download & continue
           </AlertDialogAction>

--- a/components/modals/settings/index.tsx
+++ b/components/modals/settings/index.tsx
@@ -50,7 +50,6 @@ import {
   getAvailableModels,
   getConfigIssues,
   getSelectedModelError,
-  hasAnyApiKey,
   hasRequiredKeyForModel,
 } from "@/lib/chat/config";
 import { useConfig, useUserActions } from "@/store";
@@ -159,7 +158,6 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
   // eslint-disable-next-line react-hooks/incompatible-library
   const watchedValues = form.watch();
 
-  const hasConfiguredApiKey = hasAnyApiKey(watchedValues);
   const availableEnabledModels = getAvailableModels({
     enabledModels: watchedValues.enabledModels,
     openAIKey: watchedValues.openAIKey,
@@ -168,17 +166,13 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
   });
 
   React.useEffect(() => {
-    if (!hasConfiguredApiKey) {
-      return;
-    }
-
     if (
       availableEnabledModels.length > 0 &&
       !availableEnabledModels.includes(watchedValues.selectedModel)
     ) {
       form.setValue("selectedModel", availableEnabledModels[0], { shouldValidate: true });
     }
-  }, [availableEnabledModels, form, hasConfiguredApiKey, watchedValues.selectedModel]);
+  }, [availableEnabledModels, form, watchedValues.selectedModel]);
 
   const handleClose = (next: boolean) => {
     onOpenChange(next);
@@ -198,11 +192,6 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
   };
 
   const onSubmit = (data: z.infer<typeof settingsFormSchema>) => {
-    if (!hasAnyApiKey(data)) {
-      toast.error("Please provide at least one API key.");
-      return;
-    }
-
     const issues = getConfigIssues(data);
 
     if (issues.noEnabledModels) {
@@ -289,23 +278,15 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
             </div>
             <Separator />
             {/* Model Selection Section */}
-            <div
-              className={`space-y-4 ${!hasConfiguredApiKey ? "opacity-50 pointer-events-none" : ""}`}
-            >
+            <div className="space-y-4">
               <div className="flex items-center gap-2">
                 <Cpu className="h-4 w-4" />
                 <h3 className="text-md font-medium">AI Models</h3>
-                {!hasConfiguredApiKey && (
-                  <Badge variant="secondary" className="text-xs">
-                    Requires API Key
-                  </Badge>
-                )}
               </div>
-              {!hasConfiguredApiKey && (
-                <p className="text-sm text-muted-foreground">
-                  Please provide at least one API key below to enable model selection.
-                </p>
-              )}
+              <p className="text-sm text-muted-foreground">
+                Local models run in your browser with no API key required. Provide API
+                keys below to unlock cloud models.
+              </p>
               {/* Available Models with Checkboxes */}
               <FormField
                 control={form.control}
@@ -314,16 +295,14 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
                   <FormItem>
                     <FormLabel>Available Models</FormLabel>
                     <FormDescription>
-                      Select which models appear in your model selector. You need valid
-                      API keys for each enabled model.
+                      Select which models appear in your model selector. Cloud models
+                      require a matching provider API key.
                     </FormDescription>
                     <FormControl>
                       <MultipleCombobox
                         options={modelOptions}
-                        value={hasConfiguredApiKey ? field.value : []}
+                        value={field.value}
                         onValueChange={(newValue) => {
-                          if (!hasConfiguredApiKey) return;
-
                           if (newValue.length > 10) {
                             toast.error("You can select a maximum of 10 models");
                             return;
@@ -331,7 +310,6 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
 
                           field.onChange(newValue);
 
-                          // Auto-select first model if enabling and none selected
                           if (
                             newValue.length > 0 &&
                             !newValue.includes(watchedValues.selectedModel)
@@ -339,14 +317,9 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
                             form.setValue("selectedModel", newValue[0] as ModelType);
                           }
                         }}
-                        placeholder={
-                          hasConfiguredApiKey
-                            ? "Select AI models..."
-                            : "Provide API keys first"
-                        }
+                        placeholder="Select AI models..."
                         searchPlaceholder="Search models..."
                         emptyText="No models found."
-                        disabled={!hasConfiguredApiKey}
                       />
                     </FormControl>
 
@@ -356,7 +329,7 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
               />
 
               {/* Default Model Selection */}
-              {hasConfiguredApiKey && watchedValues.enabledModels.length > 0 && (
+              {watchedValues.enabledModels.length > 0 && (
                 <FormField
                   control={form.control}
                   name="selectedModel"

--- a/components/modals/settings/index.tsx
+++ b/components/modals/settings/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Cpu, Eye, EyeOff, KeyRound, LogOut, Settings2, SunMoon } from "lucide-react";
+import { Cpu, Eye, EyeOff, KeyRound, LogOut, Settings2, SunMoon, X } from "lucide-react";
 import { useTheme } from "next-themes";
 import * as React from "react";
 import { useState } from "react";
@@ -40,6 +40,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
+import type { ModelValue } from "@/constants/models";
 import {
   DEFAULT_ENABLED_MODELS,
   DEFAULT_MODEL,
@@ -49,7 +50,6 @@ import {
 import {
   getAvailableModels,
   getConfigIssues,
-  getSelectedModelError,
   hasRequiredKeyForModel,
 } from "@/lib/chat/config";
 import { useConfig, useUserActions } from "@/store";
@@ -91,19 +91,33 @@ function ApiKeyField({
                 {...field}
                 type={show ? "text" : "password"}
                 placeholder={placeholder}
-                className="pr-10"
+                className={field.value ? "pr-20" : "pr-10"}
                 autoComplete="off"
               />
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="absolute right-0 top-0 h-full px-3 hover:bg-transparent"
-                aria-label={show ? `Hide ${label}` : `Show ${label}`}
-                onClick={() => setShow((s) => !s)}
-              >
-                {show ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-              </Button>
+              <div className="absolute right-0 top-0 h-full flex items-center">
+                {field.value && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-full px-2 hover:bg-transparent"
+                    aria-label={`Clear ${label}`}
+                    onClick={() => field.onChange("")}
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                )}
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-full px-3 hover:bg-transparent"
+                  aria-label={show ? `Hide ${label}` : `Show ${label}`}
+                  onClick={() => setShow((s) => !s)}
+                >
+                  {show ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                </Button>
+              </div>
             </div>
           </FormControl>
           <FormMessage />
@@ -194,32 +208,28 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
   const onSubmit = (data: z.infer<typeof settingsFormSchema>) => {
     const issues = getConfigIssues(data);
 
-    if (issues.noEnabledModels) {
+    const enabledModels =
+      issues.enabledModelsMissingKeys.length > 0
+        ? data.enabledModels.filter(
+            (m) => !issues.enabledModelsMissingKeys.includes(m as ModelValue)
+          )
+        : data.enabledModels;
+
+    if (enabledModels.length === 0) {
       toast.error("Please enable at least one model.");
       return;
     }
 
-    if (issues.selectedModelNotEnabled) {
-      return toast.error("Default model must be one of the enabled models.");
-    }
-
-    if (issues.enabledModelsMissingKeys.length > 0) {
-      toast.error("Each enabled model needs a matching provider API key.");
-      return;
-    }
-
-    const selectedModelError = getSelectedModelError(data);
-    if (selectedModelError) {
-      toast.error(selectedModelError);
-      return;
-    }
+    const selectedModel = enabledModels.includes(data.selectedModel)
+      ? data.selectedModel
+      : enabledModels[0];
 
     setConfig({
       openAIKey: data.openAIKey || "",
       anthropicKey: data.anthropicKey || "",
       googleKey: data.googleKey || "",
-      selectedModel: data.selectedModel as ModelType,
-      enabledModels: data.enabledModels as ModelType[],
+      selectedModel: selectedModel as ModelType,
+      enabledModels: enabledModels as ModelType[],
     });
     handleClose(false);
     toast.success("Settings saved successfully");

--- a/constants/models.ts
+++ b/constants/models.ts
@@ -2,7 +2,7 @@ export const REASONING_LEVELS = ["none", "low", "medium", "high", "max"] as cons
 
 export type ReasoningLevel = (typeof REASONING_LEVELS)[number];
 
-export type ModelProvider = "OpenAI" | "Anthropic" | "Google";
+export type ModelProvider = "OpenAI" | "Anthropic" | "Google" | "Local";
 
 export type ApiKeyType = "openAIKey" | "anthropicKey" | "googleKey";
 
@@ -17,11 +17,23 @@ export interface ModelDefinition {
   value: string;
   label: string;
   provider: ModelProvider;
-  requiresKey: ApiKeyType;
+  requiresKey: ApiKeyType | null;
   reasoning: ModelReasoning;
 }
 
 export const MODEL_OPTIONS = [
+  {
+    value: "local-auto",
+    label: "Local model",
+    provider: "Local",
+    requiresKey: null,
+    reasoning: {
+      configurable: false,
+      supportsTemperature: false,
+      defaultLevel: "none",
+      levels: ["none"],
+    },
+  },
   {
     value: "claude-opus-4-7",
     label: "Claude Opus 4.7",
@@ -146,8 +158,16 @@ export const MODEL_OPTIONS = [
 
 export type ModelValue = (typeof MODEL_OPTIONS)[number]["value"];
 
-export const DEFAULT_MODEL: ModelValue = "claude-sonnet-4-6";
-export const DEFAULT_ENABLED_MODELS: ModelValue[] = ["claude-sonnet-4-6", "gpt-5.4-mini"];
+export const DEFAULT_MODEL: ModelValue = "local-auto";
+export const DEFAULT_ENABLED_MODELS: ModelValue[] = [
+  "local-auto",
+  "claude-sonnet-4-6",
+  "gpt-5.4-mini",
+];
+
+export function isLocalModel(modelValue: string): boolean {
+  return getModelConfig(modelValue)?.provider === "Local";
+}
 
 export function getModelConfig(modelValue: string): ModelDefinition | undefined {
   return MODEL_OPTIONS.find((m) => m.value === modelValue);

--- a/hooks/useCircleChat.ts
+++ b/hooks/useCircleChat.ts
@@ -1,10 +1,54 @@
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { isLocalModel } from "@/constants/models";
 import { streamChatRequest } from "@/lib/chat/client";
 import type { ChatMessage, ChatStreamRequest } from "@/lib/chat/contracts";
+import { DEFAULT_SYSTEM_PROMPT } from "@/lib/chat/prompt";
+import { resolveLocalModelSpec } from "@/lib/local/capabilities";
+import { streamLocalChatRequest } from "@/lib/local/localTransport";
 import { useChat, useChatActions, useConfig } from "@/store";
 import { useManageChunks } from "./useManageChunks";
+
+const LOCAL_DOWNLOAD_TOAST_ID = "local-model-download";
+
+async function runLocalStream(options: {
+  message: string;
+  history: ChatMessage[];
+  signal: AbortSignal;
+  onChunk: (chunk: string) => void;
+}): Promise<string> {
+  const spec = await resolveLocalModelSpec();
+  let downloadToastShown = false;
+
+  const payload = [
+    { role: "system", content: DEFAULT_SYSTEM_PROMPT },
+    ...options.history.map((msg) => ({ role: msg.role, content: msg.content })),
+    { role: "user", content: options.message },
+  ];
+
+  try {
+    return await streamLocalChatRequest({
+      spec,
+      messages: payload,
+      signal: options.signal,
+      onChunk: options.onChunk,
+      onProgress: (progress) => {
+        if (progress.status === "progress" && !downloadToastShown) {
+          downloadToastShown = true;
+          toast.loading(`Downloading ${spec.label} (~${spec.approximateSizeMB}MB)…`, {
+            id: LOCAL_DOWNLOAD_TOAST_ID,
+            description: "First-run only. The model is cached for future messages.",
+          });
+        }
+      },
+    });
+  } finally {
+    if (downloadToastShown) {
+      toast.dismiss(LOCAL_DOWNLOAD_TOAST_ID);
+    }
+  }
+}
 
 export const useCircleChat = () => {
   const [isLoading, setIsLoading] = useState(false);
@@ -72,25 +116,41 @@ export const useCircleChat = () => {
     const abortController = new AbortController();
     abortControllerRef.current = abortController;
     let hasResponse = false;
-    const request = {
-      message: trimmedMessage,
-      history,
-      config: {
-        openAIKey: config.openAIKey,
-        anthropicKey: config.anthropicKey,
-        googleKey: config.googleKey,
-        selectedModel: config.selectedModel,
-        reasoningLevel: config.reasoningLevel,
-      },
-    } satisfies ChatStreamRequest;
 
-    void streamChatRequest(request, {
-      signal: abortController.signal,
-      onChunk: (chunk) => {
-        hasResponse = true;
-        accumulateChunk(assistantMessage.id, chunk);
-      },
-    })
+    const useLocal = isLocalModel(config.selectedModel);
+
+    const streamPromise = useLocal
+      ? runLocalStream({
+          message: trimmedMessage,
+          history,
+          signal: abortController.signal,
+          onChunk: (chunk: string) => {
+            hasResponse = true;
+            accumulateChunk(assistantMessage.id, chunk);
+          },
+        })
+      : streamChatRequest(
+          {
+            message: trimmedMessage,
+            history,
+            config: {
+              openAIKey: config.openAIKey,
+              anthropicKey: config.anthropicKey,
+              googleKey: config.googleKey,
+              selectedModel: config.selectedModel,
+              reasoningLevel: config.reasoningLevel,
+            },
+          } satisfies ChatStreamRequest,
+          {
+            signal: abortController.signal,
+            onChunk: (chunk) => {
+              hasResponse = true;
+              accumulateChunk(assistantMessage.id, chunk);
+            },
+          }
+        );
+
+    void streamPromise
       .then(() => {
         finishStreaming();
         setError(null);

--- a/hooks/useCircleChat.ts
+++ b/hooks/useCircleChat.ts
@@ -11,7 +11,7 @@ import { streamLocalChatRequest } from "@/lib/local/localTransport";
 import { useChat, useChatActions, useConfig } from "@/store";
 import { useManageChunks } from "./useManageChunks";
 
-const LOCAL_DOWNLOAD_TOAST_ID = "local-model-download";
+export type LocalModelStatus = "idle" | "downloading" | "loading-cache" | "ready";
 
 async function runLocalStream(options: {
   spec?: LocalModelSpec;
@@ -19,9 +19,9 @@ async function runLocalStream(options: {
   history: ChatMessage[];
   signal: AbortSignal;
   onChunk: (chunk: string) => void;
+  onModelStatus: (status: LocalModelStatus, spec: LocalModelSpec) => void;
 }): Promise<string> {
   const spec = options.spec ?? (await resolveLocalModelSpec());
-  let downloadToastShown = false;
 
   const payload = [
     { role: "system", content: DEFAULT_SYSTEM_PROMPT },
@@ -29,37 +29,33 @@ async function runLocalStream(options: {
     { role: "user", content: options.message },
   ];
 
-  try {
-    return await streamLocalChatRequest({
-      spec,
-      messages: payload,
-      signal: options.signal,
-      onChunk: options.onChunk,
+  return await streamLocalChatRequest({
+    spec,
+    messages: payload,
+    signal: options.signal,
+    onChunk: options.onChunk,
 
-      onProgress: (progress) => {
-        if (progress.status === "progress" && !downloadToastShown) {
-          downloadToastShown = true;
-          const sizeLabel =
-            spec.approximateSizeMB >= 1000
-              ? `~${(spec.approximateSizeMB / 1000).toFixed(1)} GB`
-              : `~${spec.approximateSizeMB} MB`;
-          toast.loading(`Downloading ${spec.label} (${sizeLabel})…`, {
-            id: LOCAL_DOWNLOAD_TOAST_ID,
-            description: "First-run only. The model is cached for future messages.",
-          });
-        }
-      },
-    });
-  } finally {
-    if (downloadToastShown) {
-      toast.dismiss(LOCAL_DOWNLOAD_TOAST_ID);
-    }
-  }
+    onProgress: (progress) => {
+      const cacheKey = `enki-model-downloaded-${spec.modelId}`;
+
+      if (progress.status === "ready") {
+        localStorage.setItem(cacheKey, "true");
+        options.onModelStatus("ready", spec);
+      }
+
+      if (progress.status === "download") {
+        const isCached = !!localStorage.getItem(cacheKey);
+        options.onModelStatus(isCached ? "loading-cache" : "downloading", spec);
+      }
+    },
+  });
 }
 
 export const useCircleChat = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
+  const [localModelStatus, setLocalModelStatus] = useState<LocalModelStatus>("idle");
+  const [localModelSpec, setLocalModelSpec] = useState<LocalModelSpec | null>(null);
   const isSendingRef = useRef(false);
   const abortControllerRef = useRef<AbortController | null>(null);
   const router = useRouter();
@@ -86,6 +82,7 @@ export const useCircleChat = () => {
     flushChunks();
     isSendingRef.current = false;
     setIsLoading(false);
+    setLocalModelStatus("idle");
   };
 
   const sendMessage = (message: string, localSpec?: LocalModelSpec) => {
@@ -135,6 +132,10 @@ export const useCircleChat = () => {
           onChunk: (chunk: string) => {
             hasResponse = true;
             accumulateChunk(assistantMessage.id, chunk);
+          },
+          onModelStatus: (status, spec) => {
+            setLocalModelStatus(status);
+            setLocalModelSpec(spec);
           },
         })
       : streamChatRequest(
@@ -221,5 +222,7 @@ export const useCircleChat = () => {
     sendMessage,
     stopGeneration,
     isLoading,
+    localModelStatus,
+    localModelSpec,
   };
 };

--- a/hooks/useCircleChat.ts
+++ b/hooks/useCircleChat.ts
@@ -6,22 +6,24 @@ import { streamChatRequest } from "@/lib/chat/client";
 import type { ChatMessage, ChatStreamRequest } from "@/lib/chat/contracts";
 import { DEFAULT_SYSTEM_PROMPT } from "@/lib/chat/prompt";
 import type { LocalModelSpec } from "@/lib/local/capabilities";
-import { resolveLocalModelSpec } from "@/lib/local/capabilities";
-import { streamLocalChatRequest } from "@/lib/local/localTransport";
+import {
+  MODEL_DOWNLOADED_KEY_PREFIX,
+  streamLocalChatRequest,
+} from "@/lib/local/localTransport";
 import { useChat, useChatActions, useConfig } from "@/store";
 import { useManageChunks } from "./useManageChunks";
 
 export type LocalModelStatus = "idle" | "downloading" | "loading-cache" | "ready";
 
 async function runLocalStream(options: {
-  spec?: LocalModelSpec;
+  spec: LocalModelSpec;
   message: string;
   history: ChatMessage[];
   signal: AbortSignal;
   onChunk: (chunk: string) => void;
   onModelStatus: (status: LocalModelStatus, spec: LocalModelSpec) => void;
 }): Promise<string> {
-  const spec = options.spec ?? (await resolveLocalModelSpec());
+  const { spec } = options;
 
   const payload = [
     { role: "system", content: DEFAULT_SYSTEM_PROMPT },
@@ -36,7 +38,7 @@ async function runLocalStream(options: {
     onChunk: options.onChunk,
 
     onProgress: (progress) => {
-      const cacheKey = `enki-model-downloaded-${spec.modelId}`;
+      const cacheKey = `${MODEL_DOWNLOADED_KEY_PREFIX}${spec.modelId}`;
 
       if (progress.status === "ready") {
         localStorage.setItem(cacheKey, "true");
@@ -123,9 +125,16 @@ export const useCircleChat = () => {
 
     const useLocal = isLocalModel(config.selectedModel);
 
+    if (useLocal && !localSpec) {
+      finishStreaming();
+      deleteMessage(assistantMessage.id);
+      toast.error("Local model requires consent before sending.");
+      return;
+    }
+
     const streamPromise = useLocal
       ? runLocalStream({
-          spec: localSpec,
+          spec: localSpec as LocalModelSpec,
           message: trimmedMessage,
           history,
           signal: abortController.signal,

--- a/hooks/useCircleChat.ts
+++ b/hooks/useCircleChat.ts
@@ -33,6 +33,7 @@ async function runLocalStream(options: {
       messages: payload,
       signal: options.signal,
       onChunk: options.onChunk,
+
       onProgress: (progress) => {
         if (progress.status === "progress" && !downloadToastShown) {
           downloadToastShown = true;

--- a/hooks/useCircleChat.ts
+++ b/hooks/useCircleChat.ts
@@ -5,6 +5,7 @@ import { isLocalModel } from "@/constants/models";
 import { streamChatRequest } from "@/lib/chat/client";
 import type { ChatMessage, ChatStreamRequest } from "@/lib/chat/contracts";
 import { DEFAULT_SYSTEM_PROMPT } from "@/lib/chat/prompt";
+import type { LocalModelSpec } from "@/lib/local/capabilities";
 import { resolveLocalModelSpec } from "@/lib/local/capabilities";
 import { streamLocalChatRequest } from "@/lib/local/localTransport";
 import { useChat, useChatActions, useConfig } from "@/store";
@@ -13,12 +14,13 @@ import { useManageChunks } from "./useManageChunks";
 const LOCAL_DOWNLOAD_TOAST_ID = "local-model-download";
 
 async function runLocalStream(options: {
+  spec?: LocalModelSpec;
   message: string;
   history: ChatMessage[];
   signal: AbortSignal;
   onChunk: (chunk: string) => void;
 }): Promise<string> {
-  const spec = await resolveLocalModelSpec();
+  const spec = options.spec ?? (await resolveLocalModelSpec());
   let downloadToastShown = false;
 
   const payload = [
@@ -37,7 +39,11 @@ async function runLocalStream(options: {
       onProgress: (progress) => {
         if (progress.status === "progress" && !downloadToastShown) {
           downloadToastShown = true;
-          toast.loading(`Downloading ${spec.label} (~${spec.approximateSizeMB}MB)…`, {
+          const sizeLabel =
+            spec.approximateSizeMB >= 1000
+              ? `~${(spec.approximateSizeMB / 1000).toFixed(1)} GB`
+              : `~${spec.approximateSizeMB} MB`;
+          toast.loading(`Downloading ${spec.label} (${sizeLabel})…`, {
             id: LOCAL_DOWNLOAD_TOAST_ID,
             description: "First-run only. The model is cached for future messages.",
           });
@@ -82,7 +88,7 @@ export const useCircleChat = () => {
     setIsLoading(false);
   };
 
-  const sendMessage = (message: string) => {
+  const sendMessage = (message: string, localSpec?: LocalModelSpec) => {
     if (isSendingRef.current || isLoading) {
       return;
     }
@@ -122,6 +128,7 @@ export const useCircleChat = () => {
 
     const streamPromise = useLocal
       ? runLocalStream({
+          spec: localSpec,
           message: trimmedMessage,
           history,
           signal: abortController.signal,

--- a/hooks/useCircleChat.ts
+++ b/hooks/useCircleChat.ts
@@ -61,8 +61,13 @@ export const useCircleChat = () => {
   const router = useRouter();
   const { currentConversationId, messages } = useChat();
   const { config } = useConfig();
-  const { createNewConversation, addMessage, setMessageStatus, deleteMessage } =
-    useChatActions();
+  const {
+    createNewConversation,
+    addMessage,
+    setMessageStatus,
+    deleteMessage,
+    deleteConversation,
+  } = useChatActions();
   const { accumulateChunk, flushChunks, flushIntervalRef } = useManageChunks();
 
   useEffect(() => {
@@ -192,9 +197,16 @@ export const useCircleChat = () => {
         setError(streamError);
 
         if (!hasResponse) {
-          deleteMessage(assistantMessage.id);
+          if (newConversationId) {
+            deleteConversation(newConversationId);
+          } else {
+            deleteMessage(assistantMessage.id);
+          }
         } else {
           setMessageStatus(assistantMessage.id, "error");
+          if (newConversationId) {
+            router.replace(`/c/${newConversationId}`);
+          }
         }
 
         const errorMessage = streamError.message.includes("API key")
@@ -202,10 +214,6 @@ export const useCircleChat = () => {
           : "Failed to send message. Please try again.";
 
         toast.error(errorMessage);
-
-        if (newConversationId) {
-          router.replace(`/c/${newConversationId}`);
-        }
       });
   };
 

--- a/hooks/useCircleChat.ts
+++ b/hooks/useCircleChat.ts
@@ -61,13 +61,8 @@ export const useCircleChat = () => {
   const router = useRouter();
   const { currentConversationId, messages } = useChat();
   const { config } = useConfig();
-  const {
-    createNewConversation,
-    addMessage,
-    setMessageStatus,
-    deleteMessage,
-    deleteConversation,
-  } = useChatActions();
+  const { createNewConversation, addMessage, setMessageStatus, deleteMessage } =
+    useChatActions();
   const { accumulateChunk, flushChunks, flushIntervalRef } = useManageChunks();
 
   useEffect(() => {
@@ -197,16 +192,9 @@ export const useCircleChat = () => {
         setError(streamError);
 
         if (!hasResponse) {
-          if (newConversationId) {
-            deleteConversation(newConversationId);
-          } else {
-            deleteMessage(assistantMessage.id);
-          }
+          deleteMessage(assistantMessage.id);
         } else {
           setMessageStatus(assistantMessage.id, "error");
-          if (newConversationId) {
-            router.replace(`/c/${newConversationId}`);
-          }
         }
 
         const errorMessage = streamError.message.includes("API key")
@@ -214,6 +202,10 @@ export const useCircleChat = () => {
           : "Failed to send message. Please try again.";
 
         toast.error(errorMessage);
+
+        if (newConversationId) {
+          router.replace(`/c/${newConversationId}`);
+        }
       });
   };
 

--- a/hooks/useLocalModelConsent.ts
+++ b/hooks/useLocalModelConsent.ts
@@ -8,14 +8,17 @@ export function useLocalModelConsent() {
   const [spec, setSpec] = useState<LocalModelSpec | null>(null);
   const resolverRef = useRef<((ok: boolean) => void) | null>(null);
 
-  const requestConsent = async (): Promise<boolean> => {
-    if (hasLocalModelConsent()) return true;
+  // Returns the resolved spec on success, null if the user cancelled.
+  // Resolves the spec once here so callers don't need to re-resolve.
+  const requestConsent = async (): Promise<LocalModelSpec | null> => {
     const resolved = await resolveLocalModelSpec();
+    if (hasLocalModelConsent()) return resolved;
     setSpec(resolved);
     setOpen(true);
-    return new Promise((resolve) => {
+    const confirmed = await new Promise<boolean>((resolve) => {
       resolverRef.current = resolve;
     });
+    return confirmed ? resolved : null;
   };
 
   const confirm = () => {

--- a/hooks/useLocalModelConsent.ts
+++ b/hooks/useLocalModelConsent.ts
@@ -1,0 +1,35 @@
+import { useRef, useState } from "react";
+import type { LocalModelSpec } from "@/lib/local/capabilities";
+import { resolveLocalModelSpec } from "@/lib/local/capabilities";
+import { hasLocalModelConsent, setLocalModelConsent } from "@/lib/local/consent";
+
+export function useLocalModelConsent() {
+  const [open, setOpen] = useState(false);
+  const [spec, setSpec] = useState<LocalModelSpec | null>(null);
+  const resolverRef = useRef<((ok: boolean) => void) | null>(null);
+
+  const requestConsent = async (): Promise<boolean> => {
+    if (hasLocalModelConsent()) return true;
+    const resolved = await resolveLocalModelSpec();
+    setSpec(resolved);
+    setOpen(true);
+    return new Promise((resolve) => {
+      resolverRef.current = resolve;
+    });
+  };
+
+  const confirm = () => {
+    setOpen(false);
+    setLocalModelConsent();
+    resolverRef.current?.(true);
+    resolverRef.current = null;
+  };
+
+  const cancel = () => {
+    setOpen(false);
+    resolverRef.current?.(false);
+    resolverRef.current = null;
+  };
+
+  return { open, spec, requestConsent, confirm, cancel };
+}

--- a/lib/chat/config.test.ts
+++ b/lib/chat/config.test.ts
@@ -56,4 +56,17 @@ describe("chat config helpers", () => {
       })
     ).toBe(false);
   });
+
+  it("hides local models once any API key is present", () => {
+    const guest = {
+      openAIKey: "",
+      anthropicKey: "",
+      googleKey: "",
+      enabledModels: ["local-auto", "claude-sonnet-4-6"] as const,
+    };
+    expect(getAvailableModels(guest)).toEqual(["local-auto"]);
+
+    const withKey = { ...guest, anthropicKey: "sk-ant" };
+    expect(getAvailableModels(withKey)).toEqual(["claude-sonnet-4-6"]);
+  });
 });

--- a/lib/chat/config.ts
+++ b/lib/chat/config.ts
@@ -42,10 +42,13 @@ export function hasRequiredKeyForModel(modelValue: string, config: ChatApiKeys):
 }
 
 export function getAvailableModels(config: ChatSelectionConfig): ModelValue[] {
-  return (config.enabledModels ?? []).filter(
-    (model): model is ModelValue =>
-      Boolean(getModelConfig(model)) && hasRequiredKeyForModel(model, config)
-  );
+  const suppressLocal = hasAnyApiKey(config);
+  return (config.enabledModels ?? []).filter((model): model is ModelValue => {
+    const modelConfig = getModelConfig(model);
+    if (!modelConfig) return false;
+    if (suppressLocal && modelConfig.provider === "Local") return false;
+    return hasRequiredKeyForModel(model, config);
+  });
 }
 
 export function getResolvedSelectedModel(config: ChatSelectionConfig): ModelValue | null {

--- a/lib/chat/config.ts
+++ b/lib/chat/config.ts
@@ -34,9 +34,11 @@ export function getRequiredApiKey(modelValue: string): ApiKeyType | null {
 }
 
 export function hasRequiredKeyForModel(modelValue: string, config: ChatApiKeys): boolean {
-  const requiredKey = getRequiredApiKey(modelValue);
-  if (!isSupportedApiKey(requiredKey)) return false;
-  return hasValue(config[requiredKey]);
+  const modelConfig = getModelConfig(modelValue);
+  if (!modelConfig) return false;
+  if (modelConfig.requiresKey === null) return true;
+  if (!isSupportedApiKey(modelConfig.requiresKey)) return false;
+  return hasValue(config[modelConfig.requiresKey]);
 }
 
 export function getAvailableModels(config: ChatSelectionConfig): ModelValue[] {

--- a/lib/chat/prompt.ts
+++ b/lib/chat/prompt.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_SYSTEM_PROMPT =
+  "You are EnkiAI, a helpful and knowledgeable AI assistant.";

--- a/lib/langchain/chatService.ts
+++ b/lib/langchain/chatService.ts
@@ -1,25 +1,30 @@
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { AIMessage, HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { initChatModel } from "langchain";
-import type { ModelProvider } from "@/constants/models";
 import {
   getModelConfig,
   getReasoningFields,
   supportsTemperatureAtLevel,
 } from "@/constants/models";
 import type { ChatApiKeys, ChatMessage, ChatModelConfig } from "@/lib/chat/contracts";
-
-export const DEFAULT_SYSTEM_PROMPT =
-  "You are EnkiAI, a helpful and knowledgeable AI assistant.";
+import { DEFAULT_SYSTEM_PROMPT } from "@/lib/chat/prompt";
 
 const DEFAULT_TIMEOUT_MS = 120_000;
 const DEFAULT_MAX_RETRIES = 2;
 const DEFAULT_TEMPERATURE = 0.7;
 
-const PROVIDER_PREFIX: Record<"OpenAI" | "Anthropic" | "Google", string> = {
+type CloudProvider = "OpenAI" | "Anthropic" | "Google";
+
+const PROVIDER_PREFIX: Record<CloudProvider, string> = {
   OpenAI: "openai",
   Anthropic: "anthropic",
   Google: "google-genai",
+};
+
+const PROVIDER_KEY: Record<CloudProvider, keyof ChatApiKeys> = {
+  OpenAI: "openAIKey",
+  Anthropic: "anthropicKey",
+  Google: "googleKey",
 };
 
 export interface StreamChatResponseOptions {
@@ -38,16 +43,16 @@ async function buildChatModel(
     throw new Error(`Unknown model: ${config.selectedModel}`);
   }
 
-  const PROVIDER_KEY: Record<ModelProvider, keyof ChatApiKeys> = {
-    OpenAI: "openAIKey",
-    Anthropic: "anthropicKey",
-    Google: "googleKey",
-  };
-  const apiKey = config[PROVIDER_KEY[modelConfig.provider]];
-  if (!apiKey) {
+  if (modelConfig.provider === "Local") {
     throw new Error(
-      `${modelConfig.provider} API key is required for ${modelConfig.label}.`
+      `${modelConfig.label} runs in the browser and cannot be used server-side.`
     );
+  }
+
+  const provider = modelConfig.provider;
+  const apiKey = config[PROVIDER_KEY[provider]];
+  if (!apiKey) {
+    throw new Error(`${provider} API key is required for ${modelConfig.label}.`);
   }
 
   const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
@@ -69,7 +74,7 @@ async function buildChatModel(
   }
 
   const llm = await initChatModel(
-    `${PROVIDER_PREFIX[modelConfig.provider]}:${config.selectedModel}`,
+    `${PROVIDER_PREFIX[provider]}:${config.selectedModel}`,
     fields
   );
 

--- a/lib/local/capabilities.ts
+++ b/lib/local/capabilities.ts
@@ -48,16 +48,19 @@ function isIOS(): boolean {
   );
 }
 
+function isAndroid(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return /Android/.test(navigator.userAgent);
+}
+
 export async function detectModelTier(): Promise<LocalModelTier> {
   if (typeof navigator === "undefined") return "cpu";
 
-  // WebGPU ONNX models are unreliable on iOS Safari/WebKit — always use WASM
   if (isIOS()) return "cpu";
 
   const nav = navigator as NavigatorWithGPU;
   if (!nav.gpu) return "cpu";
 
-  // Verify a real GPU adapter is available (e.g. fails in iOS simulator)
   try {
     const gpu = nav.gpu as { requestAdapter(): Promise<unknown> };
     const adapter = await gpu.requestAdapter();
@@ -65,6 +68,8 @@ export async function detectModelTier(): Promise<LocalModelTier> {
   } catch {
     return "cpu";
   }
+
+  if (isAndroid()) return "local-low";
 
   const memory = nav.deviceMemory;
   if (memory === undefined) return "local-low";

--- a/lib/local/capabilities.ts
+++ b/lib/local/capabilities.ts
@@ -45,6 +45,14 @@ export async function detectModelTier(): Promise<LocalModelTier> {
   const nav = navigator as NavigatorWithGPU;
   if (!nav.gpu) return "cpu";
 
+  try {
+    const gpu = nav.gpu as { requestAdapter(): Promise<unknown> };
+    const adapter = await gpu.requestAdapter();
+    if (!adapter) return "cpu";
+  } catch {
+    return "cpu";
+  }
+
   const memory = nav.deviceMemory;
   if (memory === undefined) return "local-low";
   if (memory >= 8) return "local-high";

--- a/lib/local/capabilities.ts
+++ b/lib/local/capabilities.ts
@@ -43,11 +43,12 @@ export async function detectModelTier(): Promise<LocalModelTier> {
   if (typeof navigator === "undefined") return "cpu";
 
   const nav = navigator as NavigatorWithGPU;
-  const hasWebGPU = Boolean(nav.gpu);
-  const memory = nav.deviceMemory ?? 0;
+  if (!nav.gpu) return "cpu";
 
-  if (hasWebGPU && memory >= 8) return "local-high";
-  if (hasWebGPU && memory >= 4) return "local-low";
+  const memory = nav.deviceMemory;
+  if (memory === undefined) return "local-low";
+  if (memory >= 8) return "local-high";
+  if (memory >= 4) return "local-low";
   return "cpu";
 }
 

--- a/lib/local/capabilities.ts
+++ b/lib/local/capabilities.ts
@@ -45,9 +45,8 @@ export async function detectModelTier(): Promise<LocalModelTier> {
   const nav = navigator as NavigatorWithGPU;
   const hasWebGPU = Boolean(nav.gpu);
   const memory = nav.deviceMemory ?? 0;
-  const cores = nav.hardwareConcurrency ?? 0;
 
-  if (hasWebGPU && memory >= 8 && cores >= 4) return "local-high";
+  if (hasWebGPU && memory >= 8) return "local-high";
   if (hasWebGPU && memory >= 4) return "local-low";
   return "cpu";
 }

--- a/lib/local/capabilities.ts
+++ b/lib/local/capabilities.ts
@@ -1,0 +1,58 @@
+export type LocalModelTier = "local-high" | "local-low" | "cpu";
+
+export type LocalDevice = "webgpu" | "wasm";
+
+export interface LocalModelSpec {
+  modelId: string;
+  device: LocalDevice;
+  dtype: "q4" | "q4f16" | "fp32";
+  label: string;
+  approximateSizeMB: number;
+}
+
+export const LOCAL_MODEL_SPECS: Record<LocalModelTier, LocalModelSpec> = {
+  "local-high": {
+    modelId: "onnx-community/gemma-4-E4B-it-ONNX",
+    device: "webgpu",
+    dtype: "q4f16",
+    label: "Gemma 4 E4B",
+    approximateSizeMB: 1500,
+  },
+  "local-low": {
+    modelId: "onnx-community/Qwen3.5-0.8B-ONNX",
+    device: "webgpu",
+    dtype: "q4",
+    label: "Qwen 3.5 0.8B",
+    approximateSizeMB: 500,
+  },
+  cpu: {
+    modelId: "HuggingFaceTB/SmolLM2-135M-Instruct",
+    device: "wasm",
+    dtype: "q4",
+    label: "SmolLM2 135M",
+    approximateSizeMB: 90,
+  },
+};
+
+interface NavigatorWithGPU extends Navigator {
+  gpu?: unknown;
+  deviceMemory?: number;
+}
+
+export async function detectModelTier(): Promise<LocalModelTier> {
+  if (typeof navigator === "undefined") return "cpu";
+
+  const nav = navigator as NavigatorWithGPU;
+  const hasWebGPU = Boolean(nav.gpu);
+  const memory = nav.deviceMemory ?? 2;
+  const cores = nav.hardwareConcurrency ?? 2;
+
+  if (hasWebGPU && memory >= 4 && cores >= 4) return "local-high";
+  if (hasWebGPU && memory >= 2) return "local-low";
+  return "cpu";
+}
+
+export async function resolveLocalModelSpec(): Promise<LocalModelSpec> {
+  const tier = await detectModelTier();
+  return LOCAL_MODEL_SPECS[tier];
+}

--- a/lib/local/capabilities.ts
+++ b/lib/local/capabilities.ts
@@ -39,12 +39,25 @@ interface NavigatorWithGPU extends Navigator {
   deviceMemory?: number;
 }
 
+function isIOS(): boolean {
+  if (typeof navigator === "undefined") return false;
+  // iPadOS 13+ reports as MacIntel with touch support
+  return (
+    /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+    (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1)
+  );
+}
+
 export async function detectModelTier(): Promise<LocalModelTier> {
   if (typeof navigator === "undefined") return "cpu";
+
+  // WebGPU ONNX models are unreliable on iOS Safari/WebKit — always use WASM
+  if (isIOS()) return "cpu";
 
   const nav = navigator as NavigatorWithGPU;
   if (!nav.gpu) return "cpu";
 
+  // Verify a real GPU adapter is available (e.g. fails in iOS simulator)
   try {
     const gpu = nav.gpu as { requestAdapter(): Promise<unknown> };
     const adapter = await gpu.requestAdapter();

--- a/lib/local/capabilities.ts
+++ b/lib/local/capabilities.ts
@@ -12,25 +12,25 @@ export interface LocalModelSpec {
 
 export const LOCAL_MODEL_SPECS: Record<LocalModelTier, LocalModelSpec> = {
   "local-high": {
-    modelId: "onnx-community/gemma-4-E4B-it-ONNX",
+    modelId: "onnx-community/gemma-4-E2B-it-ONNX",
     device: "webgpu",
     dtype: "q4f16",
-    label: "Gemma 4 E4B",
-    approximateSizeMB: 1500,
+    label: "Gemma 4 E2B",
+    approximateSizeMB: 3000,
   },
   "local-low": {
     modelId: "onnx-community/Qwen3.5-0.8B-ONNX",
     device: "webgpu",
     dtype: "q4",
     label: "Qwen 3.5 0.8B",
-    approximateSizeMB: 500,
+    approximateSizeMB: 700,
   },
   cpu: {
     modelId: "HuggingFaceTB/SmolLM2-135M-Instruct",
     device: "wasm",
     dtype: "q4",
     label: "SmolLM2 135M",
-    approximateSizeMB: 90,
+    approximateSizeMB: 200,
   },
 };
 
@@ -44,11 +44,11 @@ export async function detectModelTier(): Promise<LocalModelTier> {
 
   const nav = navigator as NavigatorWithGPU;
   const hasWebGPU = Boolean(nav.gpu);
-  const memory = nav.deviceMemory ?? 2;
-  const cores = nav.hardwareConcurrency ?? 2;
+  const memory = nav.deviceMemory ?? 0;
+  const cores = nav.hardwareConcurrency ?? 0;
 
-  if (hasWebGPU && memory >= 4 && cores >= 4) return "local-high";
-  if (hasWebGPU && memory >= 2) return "local-low";
+  if (hasWebGPU && memory >= 8 && cores >= 4) return "local-high";
+  if (hasWebGPU && memory >= 4) return "local-low";
   return "cpu";
 }
 

--- a/lib/local/consent.ts
+++ b/lib/local/consent.ts
@@ -1,0 +1,10 @@
+const CONSENT_KEY = "circle-local-model-consent";
+
+export function hasLocalModelConsent(): boolean {
+  if (typeof window === "undefined") return false;
+  return localStorage.getItem(CONSENT_KEY) === "true";
+}
+
+export function setLocalModelConsent(): void {
+  localStorage.setItem(CONSENT_KEY, "true");
+}

--- a/lib/local/consent.ts
+++ b/lib/local/consent.ts
@@ -2,9 +2,18 @@ const CONSENT_KEY = "circle-local-model-consent";
 
 export function hasLocalModelConsent(): boolean {
   if (typeof window === "undefined") return false;
-  return localStorage.getItem(CONSENT_KEY) === "true";
+  try {
+    return localStorage.getItem(CONSENT_KEY) === "true";
+  } catch {
+    return false;
+  }
 }
 
 export function setLocalModelConsent(): void {
-  localStorage.setItem(CONSENT_KEY, "true");
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(CONSENT_KEY, "true");
+  } catch {
+    // Blocked storage (private mode, Brave Shields) — consent is session-only.
+  }
 }

--- a/lib/local/inference.worker.ts
+++ b/lib/local/inference.worker.ts
@@ -105,6 +105,11 @@ async function getPipeline(
     },
   })) as TextGenerationPipeline;
 
+  if (!pipe.tokenizer.chat_template && modelId.toLowerCase().includes("gemma")) {
+    pipe.tokenizer.chat_template =
+      "{% if messages[0]['role'] == 'system' %}{% set loop_messages = messages[1:] %}{% set system_message = messages[0]['content'] %}{% else %}{% set loop_messages = messages %}{% set system_message = '' %}{% endif %}{{ bos_token }}{% for message in loop_messages %}{% if loop.index0 == 0 and system_message != '' %}{% set content = system_message + '\\n\\n' + message['content'] %}{% else %}{% set content = message['content'] %}{% endif %}{% if message['role'] == 'user' %}{{ '<start_of_turn>user\\n' + content + '<end_of_turn>\\n' }}{% elif message['role'] == 'model' or message['role'] == 'assistant' %}{{ '<start_of_turn>model\\n' + content + '<end_of_turn>\\n' }}{% endif %}{% endfor %}{% if add_generation_prompt %}{{ '<start_of_turn>model\\n' }}{% endif %}";
+  }
+
   cached = { key, pipeline: pipe };
   return pipe;
 }
@@ -135,11 +140,16 @@ scope.addEventListener("message", async (event: MessageEvent<IncomingMessage>) =
         if (abortedRequests.has(requestId)) {
           throw new AbortedError();
         }
-        scope.postMessage({
-          type: "chunk",
-          requestId,
-          text,
-        } satisfies OutgoingChunkMessage);
+
+        const cleanText = text.replace(/<end_of_turn>|<start_of_turn>|<bos>|<eos>/g, "");
+
+        if (cleanText) {
+          scope.postMessage({
+            type: "chunk",
+            requestId,
+            text: cleanText,
+          } satisfies OutgoingChunkMessage);
+        }
       },
     });
 

--- a/lib/local/inference.worker.ts
+++ b/lib/local/inference.worker.ts
@@ -10,6 +10,11 @@ import {
 
 env.allowLocalModels = false;
 
+// Optimize for mobile and prevent WASM memory crashes on iOS Safari/WebKit
+if (env.backends?.onnx?.wasm) {
+  env.backends.onnx.wasm.numThreads = 1;
+}
+
 interface GenerateMessage {
   type: "generate";
   requestId: string;

--- a/lib/local/inference.worker.ts
+++ b/lib/local/inference.worker.ts
@@ -1,0 +1,175 @@
+/// <reference lib="webworker" />
+
+import {
+  env,
+  type ProgressInfo,
+  pipeline,
+  type TextGenerationPipeline,
+  TextStreamer,
+} from "@huggingface/transformers";
+
+env.allowLocalModels = false;
+
+interface GenerateMessage {
+  type: "generate";
+  requestId: string;
+  modelId: string;
+  device: "webgpu" | "wasm";
+  dtype: "q4" | "q4f16" | "fp32";
+  messages: { role: string; content: string }[];
+  maxNewTokens?: number;
+}
+
+interface AbortMessage {
+  type: "abort";
+  requestId: string;
+}
+
+type IncomingMessage = GenerateMessage | AbortMessage;
+
+interface OutgoingProgressMessage {
+  type: "progress";
+  requestId: string;
+  progress: ProgressInfo;
+}
+
+interface OutgoingChunkMessage {
+  type: "chunk";
+  requestId: string;
+  text: string;
+}
+
+interface OutgoingCompleteMessage {
+  type: "complete";
+  requestId: string;
+}
+
+interface OutgoingAbortedMessage {
+  type: "aborted";
+  requestId: string;
+}
+
+interface OutgoingErrorMessage {
+  type: "error";
+  requestId: string;
+  error: string;
+}
+
+export type WorkerOutgoingMessage =
+  | OutgoingProgressMessage
+  | OutgoingChunkMessage
+  | OutgoingCompleteMessage
+  | OutgoingAbortedMessage
+  | OutgoingErrorMessage;
+
+const scope = self as DedicatedWorkerGlobalScope;
+
+interface PipelineCache {
+  key: string;
+  pipeline: TextGenerationPipeline;
+}
+
+let cached: PipelineCache | null = null;
+const abortedRequests = new Set<string>();
+
+class AbortedError extends Error {
+  constructor() {
+    super("Generation aborted");
+    this.name = "AbortedError";
+  }
+}
+
+async function getPipeline(
+  requestId: string,
+  modelId: string,
+  device: "webgpu" | "wasm",
+  dtype: "q4" | "q4f16" | "fp32"
+): Promise<TextGenerationPipeline> {
+  const key = `${modelId}::${device}::${dtype}`;
+  if (cached && cached.key === key) return cached.pipeline;
+
+  const pipe = (await pipeline("text-generation", modelId, {
+    device,
+    dtype,
+    progress_callback: (progress: ProgressInfo) => {
+      scope.postMessage({
+        type: "progress",
+        requestId,
+        progress,
+      } satisfies OutgoingProgressMessage);
+    },
+  })) as TextGenerationPipeline;
+
+  cached = { key, pipeline: pipe };
+  return pipe;
+}
+
+scope.addEventListener("message", async (event: MessageEvent<IncomingMessage>) => {
+  const data = event.data;
+
+  if (data.type === "abort") {
+    abortedRequests.add(data.requestId);
+    return;
+  }
+
+  if (data.type !== "generate") return;
+
+  const { requestId, modelId, device, dtype, messages, maxNewTokens = 512 } = data;
+
+  try {
+    const generator = await getPipeline(requestId, modelId, device, dtype);
+
+    if (abortedRequests.has(requestId)) {
+      throw new AbortedError();
+    }
+
+    const streamer = new TextStreamer(generator.tokenizer, {
+      skip_prompt: true,
+      skip_special_tokens: true,
+      callback_function: (text: string) => {
+        if (abortedRequests.has(requestId)) {
+          throw new AbortedError();
+        }
+        scope.postMessage({
+          type: "chunk",
+          requestId,
+          text,
+        } satisfies OutgoingChunkMessage);
+      },
+    });
+
+    await generator(messages, {
+      max_new_tokens: maxNewTokens,
+      do_sample: false,
+      streamer,
+    });
+
+    if (abortedRequests.has(requestId)) {
+      scope.postMessage({
+        type: "aborted",
+        requestId,
+      } satisfies OutgoingAbortedMessage);
+    } else {
+      scope.postMessage({
+        type: "complete",
+        requestId,
+      } satisfies OutgoingCompleteMessage);
+    }
+  } catch (error) {
+    if (error instanceof AbortedError || abortedRequests.has(requestId)) {
+      scope.postMessage({
+        type: "aborted",
+        requestId,
+      } satisfies OutgoingAbortedMessage);
+    } else {
+      const message = error instanceof Error ? error.message : "Unknown worker error";
+      scope.postMessage({
+        type: "error",
+        requestId,
+        error: message,
+      } satisfies OutgoingErrorMessage);
+    }
+  } finally {
+    abortedRequests.delete(requestId);
+  }
+});

--- a/lib/local/localTransport.ts
+++ b/lib/local/localTransport.ts
@@ -17,6 +17,7 @@ export interface StreamLocalChatOptions {
 }
 
 const TRANSFORMERS_CACHE_KEY = "transformers-cache";
+export const MODEL_DOWNLOADED_KEY_PREFIX = "enki-model-downloaded-";
 
 let worker: Worker | null = null;
 let requestCounter = 0;
@@ -50,6 +51,13 @@ export async function clearLocalModelCache(): Promise<void> {
     worker.terminate();
     worker = null;
   }
+  try {
+    for (const key of Object.keys(localStorage)) {
+      if (key.startsWith(MODEL_DOWNLOADED_KEY_PREFIX)) localStorage.removeItem(key);
+    }
+  } catch {
+    // ignore blocked storage
+  }
   if (typeof caches === "undefined") return;
   try {
     await caches.delete(TRANSFORMERS_CACHE_KEY);
@@ -81,9 +89,19 @@ export async function streamLocalChatRequest(
       rejectFromOutside(error);
     };
 
+    const handleWorkerError = (event: ErrorEvent) => {
+      rejectFromOutside(new Error(event.message ?? "Worker crashed"));
+    };
+
+    const handleWorkerMessageError = () => {
+      rejectFromOutside(new Error("Worker message deserialization failed"));
+    };
+
     const cleanup = () => {
       pendingRejecters.delete(rejectFromOutside);
       w.removeEventListener("message", handleMessage);
+      w.removeEventListener("error", handleWorkerError);
+      w.removeEventListener("messageerror", handleWorkerMessageError);
       signal?.removeEventListener("abort", handleAbort);
     };
 
@@ -124,6 +142,8 @@ export async function streamLocalChatRequest(
     }
 
     w.addEventListener("message", handleMessage);
+    w.addEventListener("error", handleWorkerError, { once: true });
+    w.addEventListener("messageerror", handleWorkerMessageError, { once: true });
     signal?.addEventListener("abort", handleAbort, { once: true });
 
     w.postMessage({

--- a/lib/local/localTransport.ts
+++ b/lib/local/localTransport.ts
@@ -1,0 +1,105 @@
+import type { ProgressInfo } from "@huggingface/transformers";
+import type { LocalModelSpec } from "./capabilities";
+import type { WorkerOutgoingMessage } from "./inference.worker";
+
+export interface LocalChatMessage {
+  role: string;
+  content: string;
+}
+
+export interface StreamLocalChatOptions {
+  spec: LocalModelSpec;
+  messages: LocalChatMessage[];
+  maxNewTokens?: number;
+  signal?: AbortSignal;
+  onChunk?: (chunk: string) => void;
+  onProgress?: (progress: ProgressInfo) => void;
+}
+
+let worker: Worker | null = null;
+let requestCounter = 0;
+
+function getWorker(): Worker {
+  if (typeof window === "undefined") {
+    throw new Error("Local inference is only available in the browser.");
+  }
+
+  if (!worker) {
+    worker = new Worker(new URL("./inference.worker.ts", import.meta.url), {
+      type: "module",
+      name: "local-inference",
+    });
+  }
+
+  return worker;
+}
+
+export async function streamLocalChatRequest(
+  options: StreamLocalChatOptions
+): Promise<string> {
+  const { spec, messages, maxNewTokens = 512, signal, onChunk, onProgress } = options;
+
+  if (signal?.aborted) {
+    const error = new Error("Aborted");
+    error.name = "AbortError";
+    throw error;
+  }
+
+  const requestId = `local-${++requestCounter}-${Date.now()}`;
+  const w = getWorker();
+  let accumulated = "";
+
+  return new Promise<string>((resolve, reject) => {
+    const handleAbort = () => {
+      w.postMessage({ type: "abort", requestId });
+    };
+
+    const cleanup = () => {
+      w.removeEventListener("message", handleMessage);
+      signal?.removeEventListener("abort", handleAbort);
+    };
+
+    function handleMessage(event: MessageEvent<WorkerOutgoingMessage>) {
+      const data = event.data;
+      if (!data || data.requestId !== requestId) return;
+
+      switch (data.type) {
+        case "progress":
+          onProgress?.(data.progress);
+          break;
+        case "chunk":
+          accumulated += data.text;
+          onChunk?.(data.text);
+          break;
+        case "complete":
+          cleanup();
+          resolve(accumulated);
+          break;
+        case "aborted": {
+          cleanup();
+          const error = new Error("Aborted");
+          error.name = "AbortError";
+          reject(error);
+          break;
+        }
+        case "error":
+          cleanup();
+          reject(new Error(data.error));
+          break;
+      }
+    }
+
+    w.addEventListener("message", handleMessage);
+    signal?.addEventListener("abort", handleAbort, { once: true });
+
+    w.postMessage({
+      type: "generate",
+      requestId,
+      modelId: spec.modelId,
+      device: spec.device,
+      dtype: spec.dtype,
+      messages,
+      maxNewTokens,
+    });
+  });
+}

--- a/lib/local/localTransport.ts
+++ b/lib/local/localTransport.ts
@@ -16,8 +16,11 @@ export interface StreamLocalChatOptions {
   onProgress?: (progress: ProgressInfo) => void;
 }
 
+const TRANSFORMERS_CACHE_KEY = "transformers-cache";
+
 let worker: Worker | null = null;
 let requestCounter = 0;
+const pendingRejecters = new Set<(error: Error) => void>();
 
 function getWorker(): Worker {
   if (typeof window === "undefined") {
@@ -32,6 +35,27 @@ function getWorker(): Worker {
   }
 
   return worker;
+}
+
+export async function clearLocalModelCache(): Promise<void> {
+  if (worker) {
+    if (pendingRejecters.size > 0) {
+      const error = new Error("Aborted");
+      error.name = "AbortError";
+      for (const reject of pendingRejecters) {
+        reject(error);
+      }
+      pendingRejecters.clear();
+    }
+    worker.terminate();
+    worker = null;
+  }
+  if (typeof caches === "undefined") return;
+  try {
+    await caches.delete(TRANSFORMERS_CACHE_KEY);
+  } catch {
+    // Best-effort cleanup; ignore failures (e.g. blocked by storage policy).
+  }
 }
 
 export async function streamLocalChatRequest(
@@ -55,9 +79,16 @@ export async function streamLocalChatRequest(
     };
 
     const cleanup = () => {
+      pendingRejecters.delete(rejectFromOutside);
       w.removeEventListener("message", handleMessage);
       signal?.removeEventListener("abort", handleAbort);
     };
+
+    const rejectFromOutside = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    pendingRejecters.add(rejectFromOutside);
 
     function handleMessage(event: MessageEvent<WorkerOutgoingMessage>) {
       const data = event.data;

--- a/lib/local/localTransport.ts
+++ b/lib/local/localTransport.ts
@@ -76,6 +76,9 @@ export async function streamLocalChatRequest(
   return new Promise<string>((resolve, reject) => {
     const handleAbort = () => {
       w.postMessage({ type: "abort", requestId });
+      const error = new Error("Aborted");
+      error.name = "AbortError";
+      rejectFromOutside(error);
     };
 
     const cleanup = () => {

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,22 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  serverExternalPackages: ["langchain", "@langchain/openai", "@langchain/anthropic"],
+  serverExternalPackages: [
+    "langchain",
+    "@langchain/openai",
+    "@langchain/anthropic",
+    "@huggingface/transformers",
+    "onnxruntime-node",
+    "sharp",
+  ],
+  turbopack: {},
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      sharp$: false,
+      "onnxruntime-node$": false,
+    };
+    return config;
+  },
   images: {
     remotePatterns: [
       {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@hookform/resolvers": "^5.0.1",
+    "@huggingface/transformers": "^4.1.0",
     "@langchain/anthropic": "^1.3.26",
     "@langchain/core": "^1.1.40",
     "@langchain/google-genai": "^2.1.27",

--- a/store/index.ts
+++ b/store/index.ts
@@ -23,7 +23,7 @@ export const useStore = create<StoreState>()(
       }),
       {
         name: "chat-store",
-        version: 4,
+        version: 5,
         migrate: (persistedState, version) => {
           const state = persistedState as { config?: Partial<Config> } | undefined;
           if (version < 2 && state?.config && state.config.reasoningLevel === undefined) {
@@ -51,6 +51,14 @@ export const useStore = create<StoreState>()(
           }
           if (version < 4 && state?.config && state.config.googleKey === undefined) {
             state.config.googleKey = "";
+          }
+          if (version < 5 && state?.config) {
+            const enabled = Array.isArray(state.config.enabledModels)
+              ? state.config.enabledModels
+              : [];
+            if (!enabled.includes("local-auto")) {
+              state.config.enabledModels = ["local-auto", ...enabled];
+            }
           }
           return state;
         },

--- a/store/slices/configSlice.ts
+++ b/store/slices/configSlice.ts
@@ -4,6 +4,8 @@ import {
   DEFAULT_MODEL,
   getModelConfig,
 } from "@/constants/models";
+import { hasAnyApiKey } from "@/lib/chat/config";
+import { clearLocalModelCache } from "@/lib/local/localTransport";
 import type { Config, StoreState } from "../types";
 
 export interface ConfigSlice {
@@ -26,10 +28,12 @@ export const createConfigSlice: StateCreator<
   [["zustand/devtools", never]],
   [],
   ConfigSlice
-> = (set) => ({
+> = (set, get) => ({
   config: initialConfig,
 
-  setConfig: (newConfig) =>
+  setConfig: (newConfig) => {
+    const prevConfig = get().config;
+
     set((state) => {
       const updatedConfig = { ...state.config, ...newConfig };
 
@@ -62,7 +66,12 @@ export const createConfigSlice: StateCreator<
       return {
         config: updatedConfig,
       };
-    }),
+    });
+
+    if (!hasAnyApiKey(prevConfig) && hasAnyApiKey(get().config)) {
+      void clearLocalModelCache();
+    }
+  },
 
   clearConfig: () =>
     set(() => ({


### PR DESCRIPTION
## Summary

- Adds a `Local` provider with `local-auto` model that runs entirely in the browser — no API key required
- Detects device capabilities (WebGPU, RAM, CPU cores) and selects the best model tier automatically: Gemma 4 E4B (WebGPU high), Qwen 3.5 0.8B (WebGPU low), or SmolLM2 135M (WASM CPU fallback)
- Runs inference in a dedicated Web Worker via `@huggingface/transformers` (ONNX), keeping the UI thread unblocked
- Model weights are downloaded once and cached in the browser's Cache Storage for subsequent sessions

## Test plan

- [ ] Select "Auto (Local)" model and send a message — verify download toast appears on first run
- [ ] Verify second message uses cached model (no download toast)
- [ ] Test stop generation button mid-stream
- [ ] Verify cloud models (OpenAI, Anthropic, Google) still work normally
- [ ] Test on a device without WebGPU — verify CPU fallback (SmolLM2) is selected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running AI models locally in the browser without requiring API keys.
  * Added consent dialog for downloading and managing local models with size information.
  * Added ability to clear API keys in settings.

* **Improvements**
  * Updated chat input placeholder text to "Ask anything."
  * Settings UI now clearly indicates that local models don't require API keys, while cloud models do.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->