### PR TITLE
feat(chat): show model reasoning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ next-env.d.ts
 # personal
 mynotes.md
 ai/
+.codex/
 
 # environment
 .env

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -43,8 +43,8 @@ export async function POST(req: NextRequest) {
     const readable = new ReadableStream({
       async start(controller) {
         try {
-          for await (const chunk of stream) {
-            controller.enqueue(encoder.encode(chunk));
+          for await (const event of stream) {
+            controller.enqueue(encoder.encode(`${JSON.stringify(event)}\n`));
           }
         } catch (error: unknown) {
           console.error("Streaming error:", error);
@@ -67,7 +67,7 @@ export async function POST(req: NextRequest) {
 
     return new Response(readable, {
       headers: {
-        "Content-Type": "text/plain; charset=utf-8",
+        "Content-Type": "application/x-ndjson; charset=utf-8",
         "Cache-Control": "no-store",
       },
     });

--- a/components/Feedback/BubbleChat/BubbleChat.test.tsx
+++ b/components/Feedback/BubbleChat/BubbleChat.test.tsx
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  shouldShowPendingPlaceholder,
-  shouldShowThinkingBlock,
-} from "@/components/Feedback/BubbleChat";
+import { shouldShowPendingPlaceholder, shouldShowThinkingBlock } from ".";
 
 describe("BubbleChat", () => {
   it("does not render empty thinking UI before thinking text arrives", () => {

--- a/components/Feedback/BubbleChat/ThinkingBlock.tsx
+++ b/components/Feedback/BubbleChat/ThinkingBlock.tsx
@@ -14,7 +14,7 @@ import { MarkdownComponents } from "./MarkdownComponents";
 
 interface ThinkingBlockProps {
   thinking?: string;
-  status?: "pending" | "success" | "error" | undefined;
+  status?: "pending" | "success" | "error";
 }
 
 export function ThinkingBlock({ thinking, status }: ThinkingBlockProps) {
@@ -50,7 +50,6 @@ export function ThinkingBlock({ thinking, status }: ThinkingBlockProps) {
       </CollapsibleTrigger>
       <CollapsibleContent className="mt-1 border-muted border-l pl-3 text-muted-foreground text-sm">
         <motion.div
-          key={thinking?.length}
           initial={{ opacity: 0.7, y: 2 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.2 }}

--- a/components/Feedback/BubbleChat/ThinkingBlock.tsx
+++ b/components/Feedback/BubbleChat/ThinkingBlock.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { ChevronRight } from "lucide-react";
+import { motion } from "motion/react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+import { MarkdownComponents } from "./MarkdownComponents";
+
+interface ThinkingBlockProps {
+  thinking?: string;
+  status?: "pending" | "success" | "error" | undefined;
+}
+
+export function ThinkingBlock({ thinking, status }: ThinkingBlockProps) {
+  const isThinking = status === "pending";
+
+  return (
+    <Collapsible defaultOpen={false} className="not-prose mb-3 text-muted-foreground">
+      <CollapsibleTrigger
+        type="button"
+        className={cn(
+          "group inline-flex items-center gap-1.5 py-1 text-left text-muted-foreground text-sm",
+          "hover:text-foreground"
+        )}
+      >
+        {isThinking ? (
+          <motion.span
+            className="bg-[linear-gradient(110deg,var(--muted-foreground)_0%,var(--muted-foreground)_35%,var(--foreground)_50%,var(--muted-foreground)_65%,var(--muted-foreground)_100%)] bg-[length:220%_100%] bg-clip-text text-transparent"
+            initial={{ backgroundPosition: "220% 0" }}
+            animate={{ backgroundPosition: "-220% 0" }}
+            transition={{
+              duration: 3,
+              ease: "easeInOut",
+              repeat: Number.POSITIVE_INFINITY,
+              repeatDelay: 0.25,
+            }}
+          >
+            Thinking
+          </motion.span>
+        ) : (
+          <span>Thought</span>
+        )}
+        <ChevronRight className="h-4 w-4 transition-transform group-data-[state=open]:rotate-90" />
+      </CollapsibleTrigger>
+      <CollapsibleContent className="mt-1 border-muted border-l pl-3 text-muted-foreground text-sm">
+        <motion.div
+          key={thinking?.length}
+          initial={{ opacity: 0.7, y: 2 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.2 }}
+          className="prose prose-sm dark:prose-invert max-w-none text-muted-foreground [&_*]:text-muted-foreground"
+        >
+          <ReactMarkdown remarkPlugins={[remarkGfm]} components={MarkdownComponents}>
+            {thinking}
+          </ReactMarkdown>
+        </motion.div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/components/Feedback/BubbleChat/index.tsx
+++ b/components/Feedback/BubbleChat/index.tsx
@@ -5,22 +5,59 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { cn } from "@/lib/utils";
 import { MarkdownComponents } from "./MarkdownComponents";
+import { ThinkingBlock } from "./ThinkingBlock";
 
 interface BubbleChatProps {
   message: string;
+  thinking?: string;
   name: string;
   role?: "user" | "assistant";
   status?: "pending" | "success" | "error" | undefined;
   isLastMessage?: boolean;
 }
 
+interface ThinkingVisibilityOptions {
+  role?: "user" | "assistant";
+  thinking?: string;
+}
+
+export function shouldShowThinkingBlock({ role, thinking }: ThinkingVisibilityOptions) {
+  return role === "assistant" && Boolean(thinking?.trim());
+}
+
+export function shouldShowPendingPlaceholder({
+  message,
+  role,
+  status,
+  thinking,
+}: ThinkingVisibilityOptions & {
+  message: string;
+  status?: "pending" | "success" | "error" | undefined;
+}) {
+  return (
+    role === "assistant" && status === "pending" && !message.trim() && !thinking?.trim()
+  );
+}
+
 export const BubbleChat = ({
   message,
+  thinking,
   name,
   role = "user",
   status = "pending",
   isLastMessage = false,
 }: BubbleChatProps) => {
+  const showThinking = shouldShowThinkingBlock({
+    role,
+    thinking,
+  });
+  const showPendingPlaceholder = shouldShowPendingPlaceholder({
+    message,
+    role,
+    status,
+    thinking,
+  });
+
   return (
     <div className="w-full min-w-0 max-w-full md:max-w-2xl lg:max-w-3xl xl:max-w-4xl m-auto flex gap-4 p-4 text-base overflow-hidden">
       <div className="flex h-8 w-8 shrink-0 items-center justify-center">
@@ -44,7 +81,8 @@ export const BubbleChat = ({
               isLastMessage && "min-h-[calc(100dvh-350px)]"
             )}
           >
-            {status === "pending" ? (
+            {showThinking && <ThinkingBlock thinking={thinking} status={status} />}
+            {showPendingPlaceholder ? (
               <div className="flex gap-1">
                 <span className="animate-bounce">.</span>
                 <span className="animate-bounce delay-100">.</span>

--- a/components/Inputs/InputChat/ReasoningSelector.tsx
+++ b/components/Inputs/InputChat/ReasoningSelector.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import {
+  BrainCircuit,
+  Check,
+  ChevronDown,
+  type LucideIcon,
+  Signal,
+  SignalHigh,
+  SignalLow,
+  SignalMedium,
+  SignalZero,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { getModelConfig, type ReasoningLevel } from "@/constants/models";
+import { cn } from "@/lib/utils";
+import { useConfig } from "@/store";
+
+const LEVEL_LABELS: Record<ReasoningLevel, string> = {
+  none: "Off",
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  max: "Max",
+};
+
+const LEVEL_ICONS: Record<ReasoningLevel, LucideIcon> = {
+  none: SignalZero,
+  low: SignalLow,
+  medium: SignalMedium,
+  high: SignalHigh,
+  max: Signal,
+};
+
+export function ReasoningSelector() {
+  const { config, setConfig } = useConfig();
+  const modelConfig = getModelConfig(config.selectedModel);
+
+  if (!modelConfig?.reasoning.configurable) {
+    return null;
+  }
+
+  const levels = modelConfig.reasoning.levels;
+  const selectedLevel = levels.includes(config.reasoningLevel)
+    ? config.reasoningLevel
+    : modelConfig.reasoning.defaultLevel;
+  const SelectedSignalIcon = LEVEL_ICONS[selectedLevel];
+
+  const handleSelect = (level: ReasoningLevel) => {
+    setConfig({ reasoningLevel: level });
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className={cn(
+            "h-10 rounded-lg border-border/70 bg-background/90 px-3 text-xs shadow-none",
+            "hover:bg-accent hover:text-accent-foreground"
+          )}
+          aria-label={`Reasoning: ${LEVEL_LABELS[selectedLevel]}`}
+        >
+          <BrainCircuit className="h-4 w-4" />
+          <span>{LEVEL_LABELS[selectedLevel]}</span>
+          <SelectedSignalIcon className="h-4 w-4 text-muted-foreground" />
+          <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent side="top" align="end" className="w-40">
+        <DropdownMenuLabel className="text-xs text-muted-foreground">
+          REASONING
+        </DropdownMenuLabel>
+        {levels.map((level) => {
+          const SignalIcon = LEVEL_ICONS[level];
+          const isSelected = level === selectedLevel;
+
+          return (
+            <DropdownMenuItem
+              key={level}
+              onSelect={() => handleSelect(level)}
+              className={cn("justify-between", isSelected && "bg-accent")}
+            >
+              <span className="flex items-center gap-2">
+                <SignalIcon className="h-4 w-4" />
+                {LEVEL_LABELS[level]}
+              </span>
+              <Check
+                className={cn("h-4 w-4", isSelected ? "opacity-100" : "opacity-0")}
+              />
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/components/Inputs/InputChat/ReasoningSelector.tsx
+++ b/components/Inputs/InputChat/ReasoningSelector.tsx
@@ -11,6 +11,7 @@ import {
   SignalMedium,
   SignalZero,
 } from "lucide-react";
+import { useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -42,6 +43,15 @@ const LEVEL_ICONS: Record<ReasoningLevel, LucideIcon> = {
 export function ReasoningSelector() {
   const { config, setConfig } = useConfig();
   const modelConfig = getModelConfig(config.selectedModel);
+
+  useEffect(() => {
+    const reasoning = modelConfig?.reasoning;
+    if (!reasoning?.configurable) return;
+
+    if (!reasoning.levels.includes(config.reasoningLevel)) {
+      setConfig({ reasoningLevel: reasoning.defaultLevel });
+    }
+  }, [config.reasoningLevel, modelConfig, setConfig]);
 
   if (!modelConfig?.reasoning.configurable) {
     return null;

--- a/components/Inputs/InputChat/index.tsx
+++ b/components/Inputs/InputChat/index.tsx
@@ -4,9 +4,11 @@ import { Send, Square } from "lucide-react";
 import { type FC, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { getModelConfig } from "@/constants/models";
 import { canSendSelectedModel, getSelectedModelError } from "@/lib/chat/config";
 import { cn } from "@/lib/utils";
 import { useConfig, useUIActions } from "@/store";
+import { ReasoningSelector } from "./ReasoningSelector";
 
 interface InputChatProps {
   onSubmit: (message: string) => void;
@@ -20,6 +22,9 @@ export const InputChat: FC<InputChatProps> = ({ onSubmit, onStop, isLoading }) =
   const { config } = useConfig();
   const { setSettingsModalOpen } = useUIActions();
   const canSend = canSendSelectedModel(config);
+  const showReasoningSelector = Boolean(
+    canSend && getModelConfig(config.selectedModel)?.reasoning.configurable
+  );
   const disabledPlaceholder =
     getSelectedModelError(config) ?? "Configure your model settings to continue";
 
@@ -47,7 +52,7 @@ export const InputChat: FC<InputChatProps> = ({ onSubmit, onStop, isLoading }) =
         <Input
           className={cn(
             "min-h-[56px] w-full rounded-xl py-8 pl-4 text-base backdrop-blur-lg bg-background/50",
-            canSend ? "pr-14" : "pr-24"
+            showReasoningSelector ? "pr-[180px]" : canSend ? "pr-14" : "pr-24"
           )}
           placeholder={canSend ? "Ask anything" : disabledPlaceholder}
           value={message}
@@ -93,6 +98,11 @@ export const InputChat: FC<InputChatProps> = ({ onSubmit, onStop, isLoading }) =
           >
             Setup
           </Button>
+        )}
+        {showReasoningSelector && (
+          <div className="absolute right-14 top-1/2 -translate-y-1/2">
+            <ReasoningSelector />
+          </div>
         )}
       </div>
     </div>

--- a/components/Inputs/InputChat/index.tsx
+++ b/components/Inputs/InputChat/index.tsx
@@ -60,6 +60,11 @@ export const InputChat: FC<InputChatProps> = ({ onSubmit, onStop, isLoading }) =
           onKeyDown={handleKeyPress}
           disabled={isLoading || !canSend}
         />
+        {showReasoningSelector && (
+          <div className="absolute right-14 top-1/2 -translate-y-1/2">
+            <ReasoningSelector />
+          </div>
+        )}
         {canSend ? (
           isLoading ? (
             <Button
@@ -98,11 +103,6 @@ export const InputChat: FC<InputChatProps> = ({ onSubmit, onStop, isLoading }) =
           >
             Setup
           </Button>
-        )}
-        {showReasoningSelector && (
-          <div className="absolute right-14 top-1/2 -translate-y-1/2">
-            <ReasoningSelector />
-          </div>
         )}
       </div>
     </div>

--- a/components/chat/Thread/index.tsx
+++ b/components/chat/Thread/index.tsx
@@ -1,5 +1,5 @@
 import { BubbleChat } from "@/components/Feedback/BubbleChat";
-import type { Message } from "@/store/slices/chatSlice";
+import type { Message } from "@/store/slices/chats/types";
 
 interface ThreadProps {
   messages: Message[];
@@ -12,6 +12,7 @@ export const Thread = ({ messages }: ThreadProps) => {
         <BubbleChat
           key={message.id}
           message={message.content}
+          thinking={message.thinking}
           name={message.role === "assistant" ? "Circle" : "You"}
           role={message.role}
           status={message.status}

--- a/constants/models.test.ts
+++ b/constants/models.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getModelConfig, getReasoningFields } from "@/constants/models";
+import { getModelConfig, getReasoningFields } from "./models";
 
 describe("getReasoningFields", () => {
   it("asks Google models to include returned thoughts", () => {

--- a/constants/models.ts
+++ b/constants/models.ts
@@ -205,7 +205,7 @@ type OpenAIReasoningFields = {
 type GoogleThinkingLevel = "LOW" | "MEDIUM" | "HIGH";
 
 type GoogleReasoningFields = {
-  thinkingConfig?: { thinkingLevel: GoogleThinkingLevel };
+  thinkingConfig?: { includeThoughts: true; thinkingLevel: GoogleThinkingLevel };
 };
 
 export type ReasoningFields =
@@ -288,7 +288,7 @@ export function getReasoningFields(
   if (model.provider === "Google") {
     const thinkingLevel = GOOGLE_THINKING_LEVELS[level];
     if (!thinkingLevel) return {};
-    return { thinkingConfig: { thinkingLevel } };
+    return { thinkingConfig: { includeThoughts: true, thinkingLevel } };
   }
 
   return {};

--- a/hooks/useCircleChat.ts
+++ b/hooks/useCircleChat.ts
@@ -1,16 +1,22 @@
-import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { isLocalModel } from "@/constants/models";
 import { streamChatRequest } from "@/lib/chat/client";
-import type { ChatMessage, ChatStreamRequest } from "@/lib/chat/contracts";
+import type {
+  ChatMessage,
+  ChatModelConfig,
+  ChatStreamRequest,
+} from "@/lib/chat/contracts";
 import { DEFAULT_SYSTEM_PROMPT } from "@/lib/chat/prompt";
+import { createThinkingSplitter, type ThinkingSplitter } from "@/lib/chat/thinkingParser";
 import type { LocalModelSpec } from "@/lib/local/capabilities";
 import {
   MODEL_DOWNLOADED_KEY_PREFIX,
   streamLocalChatRequest,
 } from "@/lib/local/localTransport";
 import { useChat, useChatActions, useConfig } from "@/store";
+import type { PendingChatRequest } from "@/store/slices/chats/types";
 import { useManageChunks } from "./useManageChunks";
 
 export type LocalModelStatus = "idle" | "downloading" | "loading-cache" | "ready";
@@ -60,11 +66,21 @@ export const useCircleChat = () => {
   const [localModelSpec, setLocalModelSpec] = useState<LocalModelSpec | null>(null);
   const isSendingRef = useRef(false);
   const abortControllerRef = useRef<AbortController | null>(null);
+  const thinkingSplitterRef = useRef<ThinkingSplitter | null>(null);
+  const streamingMessageIdRef = useRef("");
   const router = useRouter();
-  const { currentConversationId, messages } = useChat();
+  const params = useParams<{ conversationId?: string }>();
+  const routeConversationId =
+    typeof params.conversationId === "string" ? params.conversationId : undefined;
+  const { currentConversationId, messages, pendingRequest } = useChat();
   const { config } = useConfig();
-  const { createNewConversation, addMessage, setMessageStatus, deleteMessage } =
-    useChatActions();
+  const {
+    createNewConversation,
+    addMessage,
+    setMessageStatus,
+    deleteMessage,
+    setPendingRequest,
+  } = useChatActions();
   const { accumulateChunk, flushChunks, flushIntervalRef } = useManageChunks();
 
   useEffect(() => {
@@ -73,8 +89,22 @@ export const useCircleChat = () => {
     };
   }, []);
 
-  const finishStreaming = () => {
+  const finishStreaming = useCallback(() => {
+    let flushedSplitter = false;
+    const splitter = thinkingSplitterRef.current;
+    const messageId = streamingMessageIdRef.current;
+
+    if (splitter && messageId) {
+      const events = splitter.flush();
+      flushedSplitter = events.length > 0;
+      for (const event of events) {
+        accumulateChunk(messageId, event);
+      }
+    }
+
     abortControllerRef.current = null;
+    thinkingSplitterRef.current = null;
+    streamingMessageIdRef.current = "";
 
     if (flushIntervalRef.current) {
       clearInterval(flushIntervalRef.current);
@@ -85,7 +115,129 @@ export const useCircleChat = () => {
     isSendingRef.current = false;
     setIsLoading(false);
     setLocalModelStatus("idle");
-  };
+
+    return flushedSplitter;
+  }, [accumulateChunk, flushChunks, flushIntervalRef]);
+
+  const startStreamingRequest = useCallback(
+    (request: PendingChatRequest) => {
+      if (isSendingRef.current || isLoading) {
+        return;
+      }
+
+      isSendingRef.current = true;
+      setError(null);
+      setIsLoading(true);
+      streamingMessageIdRef.current = request.assistantMessageId;
+
+      const useLocal = isLocalModel(request.config.selectedModel);
+
+      if (useLocal && !request.localSpec) {
+        finishStreaming();
+        deleteMessage(request.assistantMessageId);
+        toast.error("Local model requires consent before sending.");
+        return;
+      }
+
+      const abortController = new AbortController();
+      abortControllerRef.current = abortController;
+      let hasResponse = false;
+
+      const localThinkingSplitter = useLocal ? createThinkingSplitter() : null;
+      thinkingSplitterRef.current = localThinkingSplitter;
+
+      const streamPromise = useLocal
+        ? runLocalStream({
+            spec: request.localSpec as LocalModelSpec,
+            message: request.message,
+            history: request.history,
+            signal: abortController.signal,
+            onChunk: (chunk: string) => {
+              const events = localThinkingSplitter?.push(chunk) ?? [
+                { t: "content" as const, d: chunk },
+              ];
+              if (events.length > 0) {
+                hasResponse = true;
+              }
+              for (const event of events) {
+                accumulateChunk(request.assistantMessageId, event);
+              }
+            },
+            onModelStatus: (status, spec) => {
+              setLocalModelStatus(status);
+              setLocalModelSpec(spec);
+            },
+          })
+        : streamChatRequest(
+            {
+              message: request.message,
+              history: request.history,
+              config: request.config,
+            } satisfies ChatStreamRequest,
+            {
+              signal: abortController.signal,
+              onChunk: (event) => {
+                hasResponse = true;
+                accumulateChunk(request.assistantMessageId, event);
+              },
+            }
+          );
+
+      void streamPromise
+        .then(() => {
+          finishStreaming();
+          setError(null);
+          setMessageStatus(request.assistantMessageId, "success");
+        })
+        .catch((error: unknown) => {
+          const streamError =
+            error instanceof Error ? error : new Error("Unknown streaming error");
+
+          const flushedPendingResponse = finishStreaming();
+          hasResponse = hasResponse || flushedPendingResponse;
+
+          if (streamError.name === "AbortError") {
+            if (!hasResponse) {
+              deleteMessage(request.assistantMessageId);
+            } else {
+              setMessageStatus(request.assistantMessageId, "success");
+            }
+            return;
+          }
+
+          console.error("Streaming error:", streamError);
+          setError(streamError);
+
+          if (!hasResponse) {
+            deleteMessage(request.assistantMessageId);
+          } else {
+            setMessageStatus(request.assistantMessageId, "error");
+          }
+
+          const errorMessage = streamError.message.includes("API key")
+            ? "Invalid API key. Please check your settings."
+            : "Failed to send message. Please try again.";
+
+          toast.error(errorMessage);
+        });
+    },
+    [accumulateChunk, deleteMessage, finishStreaming, isLoading, setMessageStatus]
+  );
+
+  useEffect(() => {
+    if (!pendingRequest) return;
+    if (pendingRequest.conversationId !== routeConversationId) return;
+    if (pendingRequest.conversationId !== currentConversationId) return;
+
+    setPendingRequest(null);
+    startStreamingRequest(pendingRequest);
+  }, [
+    currentConversationId,
+    pendingRequest,
+    routeConversationId,
+    setPendingRequest,
+    startStreamingRequest,
+  ]);
 
   const sendMessage = (message: string, localSpec?: LocalModelSpec) => {
     if (isSendingRef.current || isLoading) {
@@ -95,14 +247,31 @@ export const useCircleChat = () => {
     const trimmedMessage = message.trim();
     if (!trimmedMessage) return;
 
-    isSendingRef.current = true;
     setError(null);
-    setIsLoading(true);
 
-    let newConversationId: string | null = null;
-    if (!currentConversationId) {
-      newConversationId = createNewConversation(trimmedMessage);
+    const useLocal = isLocalModel(config.selectedModel);
+    if (useLocal && !localSpec) {
+      toast.error("Local model requires consent before sending.");
+      return;
     }
+
+    const history: ChatMessage[] = messages.map((msg) => ({
+      role: msg.role,
+      content: msg.content,
+    }));
+
+    const requestConfig: ChatModelConfig = {
+      openAIKey: config.openAIKey,
+      anthropicKey: config.anthropicKey,
+      googleKey: config.googleKey,
+      selectedModel: config.selectedModel,
+      reasoningLevel: config.reasoningLevel,
+    };
+
+    const isNewConversation = !currentConversationId;
+    const conversationId = isNewConversation
+      ? createNewConversation(trimmedMessage)
+      : currentConversationId;
 
     addMessage({
       content: trimmedMessage,
@@ -114,108 +283,24 @@ export const useCircleChat = () => {
       role: "assistant",
     });
 
-    const history: ChatMessage[] = messages.map((msg) => ({
-      role: msg.role,
-      content: msg.content,
-    }));
+    const request: PendingChatRequest = {
+      assistantMessageId: assistantMessage.id,
+      conversationId,
+      message: trimmedMessage,
+      history,
+      config: requestConfig,
+      ...(localSpec ? { localSpec } : {}),
+    };
 
-    const abortController = new AbortController();
-    abortControllerRef.current = abortController;
-    let hasResponse = false;
-
-    const useLocal = isLocalModel(config.selectedModel);
-
-    if (useLocal && !localSpec) {
-      finishStreaming();
-      deleteMessage(assistantMessage.id);
-      toast.error("Local model requires consent before sending.");
+    if (isNewConversation) {
+      isSendingRef.current = true;
+      setIsLoading(true);
+      setPendingRequest(request);
+      router.replace(`/c/${conversationId}`);
       return;
     }
 
-    const streamPromise = useLocal
-      ? runLocalStream({
-          spec: localSpec as LocalModelSpec,
-          message: trimmedMessage,
-          history,
-          signal: abortController.signal,
-          onChunk: (chunk: string) => {
-            hasResponse = true;
-            accumulateChunk(assistantMessage.id, chunk);
-          },
-          onModelStatus: (status, spec) => {
-            setLocalModelStatus(status);
-            setLocalModelSpec(spec);
-          },
-        })
-      : streamChatRequest(
-          {
-            message: trimmedMessage,
-            history,
-            config: {
-              openAIKey: config.openAIKey,
-              anthropicKey: config.anthropicKey,
-              googleKey: config.googleKey,
-              selectedModel: config.selectedModel,
-              reasoningLevel: config.reasoningLevel,
-            },
-          } satisfies ChatStreamRequest,
-          {
-            signal: abortController.signal,
-            onChunk: (chunk) => {
-              hasResponse = true;
-              accumulateChunk(assistantMessage.id, chunk);
-            },
-          }
-        );
-
-    void streamPromise
-      .then(() => {
-        finishStreaming();
-        setError(null);
-        setMessageStatus(assistantMessage.id, "success");
-
-        if (newConversationId) {
-          router.replace(`/c/${newConversationId}`);
-        }
-      })
-      .catch((error: unknown) => {
-        const streamError =
-          error instanceof Error ? error : new Error("Unknown streaming error");
-
-        finishStreaming();
-
-        if (streamError.name === "AbortError") {
-          if (!hasResponse) {
-            deleteMessage(assistantMessage.id);
-          } else {
-            setMessageStatus(assistantMessage.id, "success");
-          }
-
-          if (newConversationId) {
-            router.replace(`/c/${newConversationId}`);
-          }
-          return;
-        }
-
-        console.error("Streaming error:", streamError);
-        setError(streamError);
-
-        if (!hasResponse) {
-          deleteMessage(assistantMessage.id);
-        } else {
-          setMessageStatus(assistantMessage.id, "error");
-        }
-
-        const errorMessage = streamError.message.includes("API key")
-          ? "Invalid API key. Please check your settings."
-          : "Failed to send message. Please try again.";
-
-        toast.error(errorMessage);
-
-        if (newConversationId) {
-          router.replace(`/c/${newConversationId}`);
-        }
-      });
+    startStreamingRequest(request);
   };
 
   const stopGeneration = () => {

--- a/hooks/useManageChunks.ts
+++ b/hooks/useManageChunks.ts
@@ -1,25 +1,43 @@
 "use client";
 
 import { useCallback, useEffect, useRef } from "react";
+import type { ChatStreamEvent } from "@/lib/chat/contracts";
 import { useChatActions } from "@/store";
 
 export const useManageChunks = () => {
-  const chunkBufferRef = useRef("");
+  const chunkBufferRef = useRef({ content: "", thinking: "" });
   const currentMessageIdRef = useRef("");
   const flushIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
-  const { updateMessageContent } = useChatActions();
+  const { updateMessageContent, updateMessageThinking } = useChatActions();
 
   const flushChunks = useCallback(() => {
-    if (chunkBufferRef.current && currentMessageIdRef.current) {
-      updateMessageContent(currentMessageIdRef.current, chunkBufferRef.current);
-      chunkBufferRef.current = "";
+    if (!currentMessageIdRef.current) {
+      return;
     }
-  }, [updateMessageContent]);
+
+    const { content, thinking } = chunkBufferRef.current;
+
+    if (content) {
+      updateMessageContent(currentMessageIdRef.current, content);
+    }
+    if (thinking) {
+      updateMessageThinking(currentMessageIdRef.current, thinking);
+    }
+
+    if (content || thinking) {
+      chunkBufferRef.current = { content: "", thinking: "" };
+    }
+  }, [updateMessageContent, updateMessageThinking]);
 
   const accumulateChunk = useCallback(
-    (messageId: string, chunk: string) => {
-      chunkBufferRef.current += chunk;
+    (messageId: string, event: ChatStreamEvent) => {
+      if (!event.d) return;
+
+      chunkBufferRef.current = {
+        ...chunkBufferRef.current,
+        [event.t]: chunkBufferRef.current[event.t] + event.d,
+      };
       currentMessageIdRef.current = messageId;
 
       if (!flushIntervalRef.current) {

--- a/hooks/useManageChunks.ts
+++ b/hooks/useManageChunks.ts
@@ -34,10 +34,7 @@ export const useManageChunks = () => {
     (messageId: string, event: ChatStreamEvent) => {
       if (!event.d) return;
 
-      chunkBufferRef.current = {
-        ...chunkBufferRef.current,
-        [event.t]: chunkBufferRef.current[event.t] + event.d,
-      };
+      chunkBufferRef.current[event.t] += event.d;
       currentMessageIdRef.current = messageId;
 
       if (!flushIntervalRef.current) {

--- a/lib/chat/bubbleChat.test.ts
+++ b/lib/chat/bubbleChat.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  shouldShowPendingPlaceholder,
+  shouldShowThinkingBlock,
+} from "@/components/Feedback/BubbleChat";
+
+describe("BubbleChat", () => {
+  it("does not render empty thinking UI before thinking text arrives", () => {
+    expect(
+      shouldShowThinkingBlock({
+        role: "assistant",
+      })
+    ).toBe(false);
+  });
+
+  it("keeps the generic pending placeholder before any tokens arrive", () => {
+    expect(
+      shouldShowPendingPlaceholder({
+        message: "",
+        role: "assistant",
+        status: "pending",
+      })
+    ).toBe(true);
+  });
+
+  it("hides the generic pending placeholder after thinking text arrives", () => {
+    expect(
+      shouldShowPendingPlaceholder({
+        message: "",
+        role: "assistant",
+        status: "pending",
+        thinking: "The model returned a thought.",
+      })
+    ).toBe(false);
+  });
+
+  it("keeps stored thinking visible after the message finishes", () => {
+    expect(
+      shouldShowThinkingBlock({
+        role: "assistant",
+        thinking: "The model returned a thought.",
+      })
+    ).toBe(true);
+  });
+});

--- a/lib/chat/client.ts
+++ b/lib/chat/client.ts
@@ -1,8 +1,12 @@
-import type { ChatStreamRequest } from "./contracts";
+import {
+  type ChatStreamEvent,
+  ChatStreamEventSchema,
+  type ChatStreamRequest,
+} from "./contracts";
 
 interface StreamChatRequestOptions {
   signal?: AbortSignal;
-  onChunk?: (chunk: string) => void;
+  onChunk?: (event: ChatStreamEvent) => void;
 }
 
 async function getErrorMessage(response: Response): Promise<string> {
@@ -42,6 +46,23 @@ export async function streamChatRequest(
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
   const responseChunks: string[] = [];
+  let lineBuffer = "";
+
+  const processLine = (line: string) => {
+    if (!line) return;
+
+    try {
+      const parsed = ChatStreamEventSchema.safeParse(JSON.parse(line));
+      if (!parsed.success) return;
+
+      if (parsed.data.t === "content") {
+        responseChunks.push(parsed.data.d);
+      }
+      options.onChunk?.(parsed.data);
+    } catch {
+      // Ignore malformed stream lines so one bad frame does not kill the response.
+    }
+  };
 
   try {
     while (true) {
@@ -51,14 +72,22 @@ export async function streamChatRequest(
       const chunk = decoder.decode(value, { stream: true });
       if (!chunk) continue;
 
-      responseChunks.push(chunk);
-      options.onChunk?.(chunk);
+      lineBuffer += chunk;
+      const lines = lineBuffer.split("\n");
+      lineBuffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        processLine(line);
+      }
     }
 
     const finalChunk = decoder.decode();
     if (finalChunk) {
-      responseChunks.push(finalChunk);
-      options.onChunk?.(finalChunk);
+      lineBuffer += finalChunk;
+    }
+    if (lineBuffer) {
+      processLine(lineBuffer);
+      lineBuffer = "";
     }
   } finally {
     reader.releaseLock();

--- a/lib/chat/contracts.ts
+++ b/lib/chat/contracts.ts
@@ -51,3 +51,10 @@ export const ChatStreamRequestSchema = z.object({
 });
 
 export type ChatStreamRequest = z.infer<typeof ChatStreamRequestSchema>;
+
+export const ChatStreamEventSchema = z.object({
+  t: z.enum(["content", "thinking"]),
+  d: z.string(),
+});
+
+export type ChatStreamEvent = z.infer<typeof ChatStreamEventSchema>;

--- a/lib/chat/reasoningFields.test.ts
+++ b/lib/chat/reasoningFields.test.ts
@@ -6,7 +6,7 @@ describe("getReasoningFields", () => {
     const model = getModelConfig("gemini-3.1-flash-lite-preview");
 
     expect(model).toBeDefined();
-    expect(model && getReasoningFields(model, "medium")).toEqual({
+    expect(getReasoningFields(model!, "medium")).toEqual({
       thinkingConfig: {
         includeThoughts: true,
         thinkingLevel: "MEDIUM",

--- a/lib/chat/reasoningFields.test.ts
+++ b/lib/chat/reasoningFields.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { getModelConfig, getReasoningFields } from "@/constants/models";
+
+describe("getReasoningFields", () => {
+  it("asks Google models to include returned thoughts", () => {
+    const model = getModelConfig("gemini-3.1-flash-lite-preview");
+
+    expect(model).toBeDefined();
+    expect(model && getReasoningFields(model, "medium")).toEqual({
+      thinkingConfig: {
+        includeThoughts: true,
+        thinkingLevel: "MEDIUM",
+      },
+    });
+  });
+});

--- a/lib/chat/thinkingParser.test.ts
+++ b/lib/chat/thinkingParser.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { createThinkingSplitter } from "./thinkingParser";
+
+describe("createThinkingSplitter", () => {
+  it("splits think tags into thinking and content events", () => {
+    const splitter = createThinkingSplitter();
+
+    expect(splitter.push("Before <think>inside</think> after")).toEqual([
+      { t: "content", d: "Before " },
+      { t: "thinking", d: "inside" },
+    ]);
+    expect(splitter.flush()).toEqual([{ t: "content", d: " after" }]);
+  });
+
+  it("preserves tags split across chunk boundaries", () => {
+    const splitter = createThinkingSplitter();
+
+    expect(splitter.push("Alpha <thi")).toEqual([{ t: "content", d: "Alp" }]);
+    expect(splitter.push("nk>Beta</thi")).toEqual([
+      { t: "content", d: "ha " },
+      { t: "thinking", d: "Be" },
+    ]);
+    expect(splitter.push("nk>Gamma")).toEqual([{ t: "thinking", d: "ta" }]);
+    expect(splitter.flush()).toEqual([{ t: "content", d: "Gamma" }]);
+  });
+
+  it("flushes unterminated thinking as thinking", () => {
+    const splitter = createThinkingSplitter();
+
+    expect(splitter.push("<think>still thinking")).toEqual([
+      { t: "thinking", d: "still t" },
+    ]);
+    expect(splitter.flush()).toEqual([{ t: "thinking", d: "hinking" }]);
+  });
+});

--- a/lib/chat/thinkingParser.test.ts
+++ b/lib/chat/thinkingParser.test.ts
@@ -32,4 +32,13 @@ describe("createThinkingSplitter", () => {
     ]);
     expect(splitter.flush()).toEqual([{ t: "thinking", d: "hinking" }]);
   });
+
+  it("rejects empty tags", () => {
+    expect(() => createThinkingSplitter("", "</think>")).toThrow(
+      "createThinkingSplitter requires non-empty openTag and closeTag"
+    );
+    expect(() => createThinkingSplitter("<think>", "")).toThrow(
+      "createThinkingSplitter requires non-empty openTag and closeTag"
+    );
+  });
 });

--- a/lib/chat/thinkingParser.ts
+++ b/lib/chat/thinkingParser.ts
@@ -1,0 +1,54 @@
+import type { ChatStreamEvent } from "./contracts";
+
+export interface ThinkingSplitter {
+  push(text: string): ChatStreamEvent[];
+  flush(): ChatStreamEvent[];
+}
+
+export function createThinkingSplitter(
+  openTag = "<think>",
+  closeTag = "</think>"
+): ThinkingSplitter {
+  let buffer = "";
+  let inThinking = false;
+  const heldTailLength = Math.max(openTag.length, closeTag.length) - 1;
+
+  const emit = (events: ChatStreamEvent[], text: string) => {
+    if (!text) return;
+    events.push({ t: inThinking ? "thinking" : "content", d: text });
+  };
+
+  return {
+    push(text) {
+      const events: ChatStreamEvent[] = [];
+      buffer += text;
+
+      while (buffer) {
+        const targetTag = inThinking ? closeTag : openTag;
+        const tagIndex = buffer.indexOf(targetTag);
+
+        if (tagIndex !== -1) {
+          emit(events, buffer.slice(0, tagIndex));
+          buffer = buffer.slice(tagIndex + targetTag.length);
+          inThinking = !inThinking;
+          continue;
+        }
+
+        const safeLength = Math.max(0, buffer.length - heldTailLength);
+        if (safeLength === 0) break;
+
+        emit(events, buffer.slice(0, safeLength));
+        buffer = buffer.slice(safeLength);
+      }
+
+      return events;
+    },
+
+    flush() {
+      const events: ChatStreamEvent[] = [];
+      emit(events, buffer);
+      buffer = "";
+      return events;
+    },
+  };
+}

--- a/lib/chat/thinkingParser.ts
+++ b/lib/chat/thinkingParser.ts
@@ -9,6 +9,10 @@ export function createThinkingSplitter(
   openTag = "<think>",
   closeTag = "</think>"
 ): ThinkingSplitter {
+  if (!openTag || !closeTag) {
+    throw new Error("createThinkingSplitter requires non-empty openTag and closeTag");
+  }
+
   let buffer = "";
   let inThinking = false;
   const heldTailLength = Math.max(openTag.length, closeTag.length) - 1;

--- a/lib/langchain/chatService.ts
+++ b/lib/langchain/chatService.ts
@@ -6,7 +6,12 @@ import {
   getReasoningFields,
   supportsTemperatureAtLevel,
 } from "@/constants/models";
-import type { ChatApiKeys, ChatMessage, ChatModelConfig } from "@/lib/chat/contracts";
+import type {
+  ChatApiKeys,
+  ChatMessage,
+  ChatModelConfig,
+  ChatStreamEvent,
+} from "@/lib/chat/contracts";
 import { DEFAULT_SYSTEM_PROMPT } from "@/lib/chat/prompt";
 
 const DEFAULT_TIMEOUT_MS = 120_000;
@@ -93,7 +98,7 @@ export async function* streamChatResponse({
   config,
   systemPrompt = DEFAULT_SYSTEM_PROMPT,
   signal,
-}: StreamChatResponseOptions): AsyncGenerator<string, void, unknown> {
+}: StreamChatResponseOptions): AsyncGenerator<ChatStreamEvent, void, unknown> {
   try {
     const historyMessages = convertToLangChainMessages(history);
     const messages = [
@@ -109,9 +114,12 @@ export async function* streamChatResponse({
     });
 
     for await (const chunk of stream) {
-      const chunkText = chunk.text;
-      if (chunkText) {
-        yield chunkText;
+      for (const block of chunk.contentBlocks) {
+        if (block.type === "text" && block.text) {
+          yield { t: "content", d: block.text };
+        } else if (block.type === "reasoning" && block.reasoning) {
+          yield { t: "thinking", d: block.reasoning };
+        }
       }
     }
   } catch (error) {

--- a/store/index.ts
+++ b/store/index.ts
@@ -6,7 +6,7 @@ import {
   getModelConfig,
   MODEL_VALUES,
 } from "@/constants/models";
-import { createChatSlice } from "./slices/chatSlice";
+import { createChatSlice } from "./slices/chats/chatSlice";
 import { createConfigSlice } from "./slices/configSlice";
 import { createUISlice } from "./slices/uiSlice";
 import { createUserSlice } from "./slices/userSlice";
@@ -23,7 +23,7 @@ export const useStore = create<StoreState>()(
       }),
       {
         name: "chat-store",
-        version: 5,
+        version: 6,
         migrate: (persistedState, version) => {
           const state = persistedState as { config?: Partial<Config> } | undefined;
           if (version < 2 && state?.config && state.config.reasoningLevel === undefined) {
@@ -59,6 +59,9 @@ export const useStore = create<StoreState>()(
             if (!enabled.includes("local-auto")) {
               state.config.enabledModels = ["local-auto", ...enabled];
             }
+          }
+          if (version < 6) {
+            // Message thinking is optional, so existing persisted chats need no backfill.
           }
           return state;
         },
@@ -108,6 +111,7 @@ export const useChat = () => {
 export const useChatActions = () => {
   const addMessage = useStore((state) => state.addMessage);
   const setChatError = useStore((state) => state.setChatError);
+  const setPendingRequest = useStore((state) => state.setPendingRequest);
   const clearChat = useStore((state) => state.clearChat);
   const createNewConversation = useStore((state) => state.createNewConversation);
   const setCurrentConversation = useStore((state) => state.setCurrentConversation);
@@ -115,6 +119,7 @@ export const useChatActions = () => {
   const deleteConversation = useStore((state) => state.deleteConversation);
   const deleteMessage = useStore((state) => state.deleteMessage);
   const updateMessageContent = useStore((state) => state.updateMessageContent);
+  const updateMessageThinking = useStore((state) => state.updateMessageThinking);
   const deleteLastMessage = useStore((state) => state.deleteLastMessage);
   const lastMessageToError = useStore((state) => state.lastMessageToError);
   const setMessageStatus = useStore((state) => state.setMessageStatus);
@@ -122,6 +127,7 @@ export const useChatActions = () => {
   return {
     addMessage,
     setChatError,
+    setPendingRequest,
     clearChat,
     createNewConversation,
     setCurrentConversation,
@@ -129,6 +135,7 @@ export const useChatActions = () => {
     deleteConversation,
     deleteMessage,
     updateMessageContent,
+    updateMessageThinking,
     deleteLastMessage,
     setMessageStatus,
     lastMessageToError,

--- a/store/slices/chats/chatSlice.ts
+++ b/store/slices/chats/chatSlice.ts
@@ -1,80 +1,7 @@
 import type { StateCreator } from "zustand";
-import type { StoreState } from "../types";
-
-type MessageStatus = "pending" | "success" | "error";
-
-export interface Message {
-  id: string;
-  content: string;
-  role: "user" | "assistant";
-  timestamp: number;
-  status: MessageStatus;
-}
-
-export interface Conversation {
-  id: string;
-  title: string;
-  messages: Message[];
-  lastModified: number;
-}
-
-export interface ChatSlice {
-  chat: {
-    conversations: Conversation[];
-    currentConversationId: string | null;
-    error: string | null;
-  };
-  addMessage: (message: Omit<Message, "id" | "timestamp" | "status">) => Message;
-  setChatError: (error: string | null) => void;
-  clearChat: () => void;
-  createNewConversation: (initialMessage: string) => string;
-  setCurrentConversation: (conversationId: string | null) => void;
-  updateConversationTitle: (conversationId: string, title: string) => void;
-  deleteConversation: (conversationId: string) => void;
-  deleteMessage: (messageId: string) => void;
-  deleteLastMessage: () => void;
-  updateMessageContent: (messageId: string, additionalContent: string) => void;
-  setMessageStatus: (messageId: string, status: MessageStatus) => void;
-  lastMessageToError: () => void;
-}
-
-const getCurrentConversationIndex = (state: StoreState) => {
-  return state.chat.conversations.findIndex(
-    (conv) => conv.id === state.chat.currentConversationId
-  );
-};
-
-const findMessageLocation = (state: StoreState, messageId: string) => {
-  const currentConversationIndex = getCurrentConversationIndex(state);
-
-  if (currentConversationIndex !== -1) {
-    const currentConversation = state.chat.conversations[currentConversationIndex];
-    const messageIndex = currentConversation.messages.findIndex(
-      (msg) => msg.id === messageId
-    );
-
-    if (messageIndex !== -1) {
-      return { conversationIndex: currentConversationIndex, messageIndex };
-    }
-  }
-
-  for (
-    let conversationIndex = 0;
-    conversationIndex < state.chat.conversations.length;
-    conversationIndex++
-  ) {
-    if (conversationIndex === currentConversationIndex) continue;
-
-    const conversation = state.chat.conversations[conversationIndex];
-    const messageIndex = conversation.messages.findIndex((msg) => msg.id === messageId);
-
-    if (messageIndex !== -1) {
-      return { conversationIndex, messageIndex };
-    }
-  }
-
-  return null;
-};
+import type { StoreState } from "../../types";
+import { findMessageLocation, getCurrentConversationIndex } from "./helpers";
+import type { ChatSlice, Conversation, Message, MessageStatus } from "./types";
 
 export const createChatSlice: StateCreator<
   StoreState,
@@ -86,6 +13,7 @@ export const createChatSlice: StateCreator<
     conversations: [],
     currentConversationId: null,
     error: null,
+    pendingRequest: null,
   },
 
   createNewConversation: (initialMessage) => {
@@ -210,6 +138,14 @@ export const createChatSlice: StateCreator<
 
   setChatError: (error) => set((state) => ({ chat: { ...state.chat, error } })),
 
+  setPendingRequest: (pendingRequest) =>
+    set((state) => ({
+      chat: {
+        ...state.chat,
+        pendingRequest,
+      },
+    })),
+
   clearChat: () =>
     set((state) => {
       const conversations = [...state.chat.conversations];
@@ -290,6 +226,40 @@ export const createChatSlice: StateCreator<
         ...conversation.messages[messageIndex],
         status: "success" as const,
         content: conversation.messages[messageIndex].content + additionalContent,
+      };
+
+      const updatedMessages = [...conversation.messages];
+      updatedMessages[messageIndex] = updatedMessage;
+
+      const updatedConversation = {
+        ...conversation,
+        messages: updatedMessages,
+        lastModified: Date.now(),
+      };
+
+      const updatedConversations = [...state.chat.conversations];
+      updatedConversations[conversationIndex] = updatedConversation;
+
+      return {
+        chat: {
+          ...state.chat,
+          conversations: updatedConversations,
+        },
+      };
+    }),
+
+  updateMessageThinking: (messageId, additionalThinking) =>
+    set((state) => {
+      const location = findMessageLocation(state, messageId);
+      if (!location) return state;
+
+      const { conversationIndex, messageIndex } = location;
+      const conversation = state.chat.conversations[conversationIndex];
+      const message = conversation.messages[messageIndex];
+
+      const updatedMessage = {
+        ...message,
+        thinking: `${message.thinking ?? ""}${additionalThinking}`,
       };
 
       const updatedMessages = [...conversation.messages];

--- a/store/slices/chats/helpers.ts
+++ b/store/slices/chats/helpers.ts
@@ -1,0 +1,39 @@
+import type { StoreState } from "../../types";
+
+export const getCurrentConversationIndex = (state: StoreState) => {
+  return state.chat.conversations.findIndex(
+    (conv) => conv.id === state.chat.currentConversationId
+  );
+};
+
+export const findMessageLocation = (state: StoreState, messageId: string) => {
+  const currentConversationIndex = getCurrentConversationIndex(state);
+
+  if (currentConversationIndex !== -1) {
+    const currentConversation = state.chat.conversations[currentConversationIndex];
+    const messageIndex = currentConversation.messages.findIndex(
+      (msg) => msg.id === messageId
+    );
+
+    if (messageIndex !== -1) {
+      return { conversationIndex: currentConversationIndex, messageIndex };
+    }
+  }
+
+  for (
+    let conversationIndex = 0;
+    conversationIndex < state.chat.conversations.length;
+    conversationIndex++
+  ) {
+    if (conversationIndex === currentConversationIndex) continue;
+
+    const conversation = state.chat.conversations[conversationIndex];
+    const messageIndex = conversation.messages.findIndex((msg) => msg.id === messageId);
+
+    if (messageIndex !== -1) {
+      return { conversationIndex, messageIndex };
+    }
+  }
+
+  return null;
+};

--- a/store/slices/chats/types.ts
+++ b/store/slices/chats/types.ts
@@ -1,0 +1,52 @@
+import type { ChatMessage, ChatModelConfig } from "@/lib/chat/contracts";
+import type { LocalModelSpec } from "@/lib/local/capabilities";
+
+export type MessageStatus = "pending" | "success" | "error";
+
+export interface Message {
+  id: string;
+  content: string;
+  thinking?: string;
+  role: "user" | "assistant";
+  timestamp: number;
+  status: MessageStatus;
+}
+
+export interface Conversation {
+  id: string;
+  title: string;
+  messages: Message[];
+  lastModified: number;
+}
+
+export interface PendingChatRequest {
+  conversationId: string;
+  assistantMessageId: string;
+  message: string;
+  history: ChatMessage[];
+  config: ChatModelConfig;
+  localSpec?: LocalModelSpec;
+}
+
+export interface ChatSlice {
+  chat: {
+    conversations: Conversation[];
+    currentConversationId: string | null;
+    error: string | null;
+    pendingRequest: PendingChatRequest | null;
+  };
+  addMessage: (message: Omit<Message, "id" | "timestamp" | "status">) => Message;
+  setChatError: (error: string | null) => void;
+  setPendingRequest: (request: PendingChatRequest | null) => void;
+  clearChat: () => void;
+  createNewConversation: (initialMessage: string) => string;
+  setCurrentConversation: (conversationId: string | null) => void;
+  updateConversationTitle: (conversationId: string, title: string) => void;
+  deleteConversation: (conversationId: string) => void;
+  deleteMessage: (messageId: string) => void;
+  deleteLastMessage: () => void;
+  updateMessageContent: (messageId: string, additionalContent: string) => void;
+  updateMessageThinking: (messageId: string, additionalThinking: string) => void;
+  setMessageStatus: (messageId: string, status: MessageStatus) => void;
+  lastMessageToError: () => void;
+}

--- a/store/types.ts
+++ b/store/types.ts
@@ -1,6 +1,6 @@
 import type { ModelValue, ReasoningLevel } from "@/constants/models";
 import type { ChatApiKeys } from "@/lib/chat/contracts";
-import type { ChatSlice } from "./slices/chatSlice";
+import type { ChatSlice } from "./slices/chats/types";
 import type { ConfigSlice } from "./slices/configSlice";
 import type { UISlice } from "./slices/uiSlice";
 import type { UserSlice } from "./slices/userSlice";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,7 +20,11 @@ export default defineConfig({
         test: {
           name: "unit",
           environment: "node",
-          include: ["lib/**/*.test.ts"],
+          include: [
+            "components/**/*.test.{ts,tsx}",
+            "constants/**/*.test.ts",
+            "lib/**/*.test.ts",
+          ],
         },
       },
       {


### PR DESCRIPTION
## Summary
- add reasoning level selector in the chat input
- stream reasoning/content as structured NDJSON events
- render assistant reasoning in a collapsible markdown block
- split chat slice internals under store/slices/chats

## Verification
- ./node_modules/.bin/tsc --noEmit
- bun lint
- bun test --project=unit
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying AI model thinking and reasoning blocks in chat conversations.
  * Introduced collapsible thinking blocks that users can expand to view the model's reasoning process.
  * Added reasoning level selector when supported by the selected AI model.

* **Tests**
  * Added comprehensive test coverage for new thinking and reasoning functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->