### PR TITLE
refactor: use ternary for JSX conditional rendering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,10 @@ Required environment variables:
 - Use conventional commit messages
 - Follow existing component patterns and naming conventions
 
+### React / JSX Conventions
+
+- Use ternary (`cond ? <JSX /> : null`) instead of `&&` for conditional rendering inside JSX. Prevents accidentally rendering `0`, `NaN`, or `""` when the left operand is not a boolean. Applies only to JSX render positions (`{cond && <JSX>}`) — keep `&&` in `if`-conditions, return expressions, `cn()` arguments, ternary conditions, and other JS logical expressions.
+
 ### Linear Task Management
 
 - When working with Linear MCP or Linear Tasks, never move tasks to completed status

--- a/app/auth/auth-error/page.tsx
+++ b/app/auth/auth-error/page.tsx
@@ -50,7 +50,7 @@ export default function AuthErrorPage() {
           className="w-full rounded-md border border-destructive/30 bg-destructive/5 p-4 text-left text-sm"
         >
           <p className="font-semibold">Error: {errorDetails.error}</p>
-          {errorDetails.errorCode && <p>Code: {errorDetails.errorCode}</p>}
+          {errorDetails.errorCode ? <p>Code: {errorDetails.errorCode}</p> : null}
           <p className="mt-2">{errorDetails.errorDescription}</p>
         </div>
 

--- a/components/Feedback/BubbleChat/index.tsx
+++ b/components/Feedback/BubbleChat/index.tsx
@@ -81,7 +81,7 @@ export const BubbleChat = ({
               isLastMessage && "min-h-[calc(100dvh-350px)]"
             )}
           >
-            {showThinking && <ThinkingBlock thinking={thinking} status={status} />}
+            {showThinking ? <ThinkingBlock thinking={thinking} status={status} /> : null}
             {showPendingPlaceholder ? (
               <div className="flex gap-1">
                 <span className="animate-bounce">.</span>

--- a/components/Inputs/InputChat/index.tsx
+++ b/components/Inputs/InputChat/index.tsx
@@ -60,11 +60,11 @@ export const InputChat: FC<InputChatProps> = ({ onSubmit, onStop, isLoading }) =
           onKeyDown={handleKeyPress}
           disabled={isLoading || !canSend}
         />
-        {showReasoningSelector && (
+        {showReasoningSelector ? (
           <div className="absolute right-14 top-1/2 -translate-y-1/2">
             <ReasoningSelector />
           </div>
-        )}
+        ) : null}
         {canSend ? (
           isLoading ? (
             <Button

--- a/components/Inputs/InputConfig/index.tsx
+++ b/components/Inputs/InputConfig/index.tsx
@@ -36,7 +36,7 @@ export const InputConfig: FC<InputConfigProps> = ({
           value={value}
           onChange={onChange}
         />
-        {type === "password" && (
+        {type === "password" ? (
           <Button
             type="button"
             variant="ghost"
@@ -53,7 +53,7 @@ export const InputConfig: FC<InputConfigProps> = ({
               {showPassword ? "Hide password" : "Show password"}
             </span>
           </Button>
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/components/modals/settings/index.tsx
+++ b/components/modals/settings/index.tsx
@@ -95,7 +95,7 @@ function ApiKeyField({
                 autoComplete="off"
               />
               <div className="absolute right-0 top-0 h-full flex items-center">
-                {field.value && (
+                {field.value ? (
                   <Button
                     type="button"
                     variant="ghost"
@@ -106,7 +106,7 @@ function ApiKeyField({
                   >
                     <X className="h-4 w-4" />
                   </Button>
-                )}
+                ) : null}
                 <Button
                   type="button"
                   variant="ghost"
@@ -339,7 +339,7 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
               />
 
               {/* Default Model Selection */}
-              {watchedValues.enabledModels.length > 0 && (
+              {watchedValues.enabledModels.length > 0 ? (
                 <FormField
                   control={form.control}
                   name="selectedModel"
@@ -372,7 +372,7 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
                     </FormItem>
                   )}
                 />
-              )}
+              ) : null}
             </div>
             <Separator />
             {/* API Keys Section */}

--- a/components/nav-main.tsx
+++ b/components/nav-main.tsx
@@ -54,13 +54,13 @@ export function NavMain({
                 <item.icon className="size-4 shrink-0 text-muted-foreground" />
               </div>
               <span>{item.title}</span>
-              {item.shortcut && !isMobile && (
+              {item.shortcut && !isMobile ? (
                 <kbd className="ml-auto hidden items-center gap-0.5 text-xs text-muted-foreground group-hover/navitem:inline-flex">
                   {isMac ? <Command className="size-3" /> : "Ctrl"}{" "}
-                  {item.shiftKey && "Shift "}
+                  {item.shiftKey ? "Shift " : null}
                   {item.shortcut}
                 </kbd>
-              )}
+              ) : null}
             </button>
           </SidebarMenuButton>
         </SidebarMenuItem>

--- a/components/nav-secondary.tsx
+++ b/components/nav-secondary.tsx
@@ -38,7 +38,7 @@ export function NavSecondary({
                   <span>{item.title}</span>
                 </a>
               </SidebarMenuButton>
-              {item.badge && <SidebarMenuBadge>{item.badge}</SidebarMenuBadge>}
+              {item.badge ? <SidebarMenuBadge>{item.badge}</SidebarMenuBadge> : null}
             </SidebarMenuItem>
           ))}
         </SidebarMenu>

--- a/components/ui/multiple-combobox.tsx
+++ b/components/ui/multiple-combobox.tsx
@@ -74,25 +74,25 @@ export function MultipleCombobox({
           disabled={disabled}
         >
           <div className="flex flex-wrap gap-1 flex-1 min-w-0">
-            {selectedOptions.length === 0 && (
+            {selectedOptions.length === 0 ? (
               <span className="text-muted-foreground truncate">{placeholder}</span>
-            )}
+            ) : null}
 
-            {selectedOptions.length === 1 && (
+            {selectedOptions.length === 1 ? (
               <div className="flex items-center gap-1 min-w-0 flex-1">
                 <span className="truncate">{selectedOptions[0].label}</span>
-                {selectedOptions[0].badge && (
+                {selectedOptions[0].badge ? (
                   <Badge
                     variant="secondary"
                     className="text-xs shrink-0 hidden sm:inline-flex"
                   >
                     {selectedOptions[0].badge}
                   </Badge>
-                )}
+                ) : null}
               </div>
-            )}
+            ) : null}
 
-            {selectedOptions.length > 1 && (
+            {selectedOptions.length > 1 ? (
               <div className="flex flex-wrap gap-1 min-w-0 flex-1">
                 <Badge variant="secondary" className="text-xs shrink-0">
                   {selectedOptions.length} selected
@@ -111,11 +111,11 @@ export function MultipleCombobox({
                       <X className="h-3 w-3 ml-1 shrink-0 hover:text-destructive" />
                     </Badge>
                   ))}
-                  {selectedOptions.length > 2 && (
+                  {selectedOptions.length > 2 ? (
                     <Badge variant="outline" className="text-xs shrink-0">
                       +{selectedOptions.length - 2}
                     </Badge>
-                  )}
+                  ) : null}
                 </div>
 
                 {/* Mobile: Show compact view */}
@@ -143,7 +143,7 @@ export function MultipleCombobox({
                   )}
                 </div>
               </div>
-            )}
+            ) : null}
           </div>
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
@@ -178,20 +178,20 @@ export function MultipleCombobox({
                         <span className="text-sm font-medium truncate">
                           {option.label}
                         </span>
-                        {option.description && (
+                        {option.description ? (
                           <span className="text-xs text-muted-foreground line-clamp-2 sm:line-clamp-1">
                             {option.description}
                           </span>
-                        )}
+                        ) : null}
                       </div>
-                      {option.badge && (
+                      {option.badge ? (
                         <Badge
                           variant="secondary"
                           className="text-xs shrink-0 self-start sm:self-center"
                         >
                           {option.badge}
                         </Badge>
-                      )}
+                      ) : null}
                     </div>
                   </CommandItem>
                 );

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -774,9 +774,9 @@ function SidebarMenuSkeleton({
       className={cn("flex h-8 items-center gap-2 rounded-md px-2", className)}
       {...props}
     >
-      {showIcon && (
+      {showIcon ? (
         <Skeleton className="size-4 rounded-md" data-sidebar="menu-skeleton-icon" />
-      )}
+      ) : null}
       <Skeleton
         className="h-4 max-w-(--skeleton-width) flex-1"
         data-sidebar="menu-skeleton-text"

--- a/stories/DesignSystem/Colors.stories.tsx
+++ b/stories/DesignSystem/Colors.stories.tsx
@@ -31,11 +31,11 @@ const ColorPalette = () => {
         <div style={{ fontSize: "12px", color: "#666", fontFamily: "monospace" }}>
           {color}
         </div>
-        {description && (
+        {description ? (
           <div style={{ fontSize: "12px", color: "#888", marginTop: "4px" }}>
             {description}
           </div>
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/stories/DesignSystem/Components.stories.tsx
+++ b/stories/DesignSystem/Components.stories.tsx
@@ -65,11 +65,11 @@ const Components = () => {
       <h4 style={{ fontSize: "14px", fontWeight: "500", marginBottom: "8px" }}>
         {title}
       </h4>
-      {description && (
+      {description ? (
         <p style={{ fontSize: "12px", color: "#666", marginBottom: "12px" }}>
           {description}
         </p>
-      )}
+      ) : null}
       <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
         {children}
       </div>


### PR DESCRIPTION
## Summary
- Replace `&&` with ternary (`cond ? <JSX /> : null`) in JSX render positions across 11 component/story files to avoid the React footgun of rendering `0`, `NaN`, or `""` when the left operand is a non-boolean.
- Document the convention in `AGENTS.md` under a new "React / JSX Conventions" section. Scope is narrow: JSX render positions only — `&&` stays in `if`-conditions, return expressions, `cn()` arguments, and ternary conditions.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `bun lint` — only pre-existing a11y warnings in `nav-chat-history.tsx`
- [x] `bun run build` succeeds
- [x] `bun test --project=unit` — 14/14 pass
- [ ] Visually smoke-test settings modal, sidebar skeleton, multiple-combobox, auth-error page