### PR TITLE
perf(chat): reduce streaming persistence overhead

### DIFF
--- a/components/Feedback/BubbleChat/CodeBlock.tsx
+++ b/components/Feedback/BubbleChat/CodeBlock.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion } from "motion/react";
-import { useState } from "react";
+import { memo, useState } from "react";
 import { HiCheck, HiOutlineClipboard } from "react-icons/hi2";
 import { LuArrowRightFromLine, LuWrapText } from "react-icons/lu";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
@@ -26,7 +26,7 @@ const fadeInAnimation = {
   transition: { duration: 0.3 },
 };
 
-export const CodeBlock = ({ language, children }: CodeBlockProps) => {
+const CodeBlockComponent = ({ language, children }: CodeBlockProps) => {
   const [isWrapped, setIsWrapped] = useState(true);
   const [isCopied, setIsCopied] = useState(false);
 
@@ -132,3 +132,5 @@ export const CodeBlock = ({ language, children }: CodeBlockProps) => {
     </motion.div>
   );
 };
+
+export const CodeBlock = memo(CodeBlockComponent);

--- a/store/index.ts
+++ b/store/index.ts
@@ -6,6 +6,7 @@ import {
   getModelConfig,
   MODEL_VALUES,
 } from "@/lib/models";
+import { dedupedJSONStorage, type PersistedSlice } from "./persistStorage";
 import { createChatSlice } from "./slices/chats/chatSlice";
 import { createConfigSlice } from "./slices/configSlice";
 import { createStreamingSlice } from "./slices/streamingSlice";
@@ -26,6 +27,11 @@ export const useStore = create<StoreState>()(
       {
         name: "chat-store",
         version: 6,
+        // Reference-deduped JSON storage. Streaming chunk mutations only touch
+        // the streaming slice (excluded from partialize), so chat.conversations
+        // and config references stay stable per chunk and the write is skipped
+        // entirely. See persistStorage.ts.
+        storage: dedupedJSONStorage,
         migrate: (persistedState, version) => {
           const state = persistedState as { config?: Partial<Config> } | undefined;
           if (version < 2 && state?.config && state.config.reasoningLevel === undefined) {
@@ -65,9 +71,9 @@ export const useStore = create<StoreState>()(
           if (version < 6) {
             // Message thinking is optional, so existing persisted chats need no backfill.
           }
-          return state;
+          return state as PersistedSlice;
         },
-        partialize: (state) => ({
+        partialize: (state): PersistedSlice => ({
           chat: {
             conversations: state.chat.conversations,
           },

--- a/store/index.ts
+++ b/store/index.ts
@@ -27,10 +27,6 @@ export const useStore = create<StoreState>()(
       {
         name: "chat-store",
         version: 6,
-        // Reference-deduped JSON storage. Streaming chunk mutations only touch
-        // the streaming slice (excluded from partialize), so chat.conversations
-        // and config references stay stable per chunk and the write is skipped
-        // entirely. See persistStorage.ts.
         storage: dedupedJSONStorage,
         migrate: (persistedState, version) => {
           const state = persistedState as { config?: Partial<Config> } | undefined;

--- a/store/persistStorage.test.ts
+++ b/store/persistStorage.test.ts
@@ -133,7 +133,9 @@ describe("dedupedJSONStorage", () => {
       config: v1.state.config,
     });
     dedupedJSONStorage.setItem(NAME, v2);
-    expect(warnSpy).toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("localStorage quota exceeded")
+    );
 
     // After quota failure, dedupe refs are reset; same payload retries on next call.
     storage.setItem.mockClear();

--- a/store/persistStorage.test.ts
+++ b/store/persistStorage.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { dedupedJSONStorage, type PersistedSlice } from "./persistStorage";
+
+const NAME = "chat-store";
+
+class MemoryStorage {
+  private map = new Map<string, string>();
+  getItem = vi.fn((k: string) => this.map.get(k) ?? null);
+  setItem = vi.fn((k: string, v: string) => {
+    this.map.set(k, v);
+  });
+  removeItem = vi.fn((k: string) => {
+    this.map.delete(k);
+  });
+  clear = () => this.map.clear();
+}
+
+let storage: MemoryStorage;
+const originalWindow = globalThis.window;
+
+beforeEach(() => {
+  storage = new MemoryStorage();
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: { localStorage: storage },
+  });
+  dedupedJSONStorage.removeItem(NAME);
+});
+
+afterEach(() => {
+  if (originalWindow === undefined) {
+    Reflect.deleteProperty(globalThis, "window");
+    return;
+  }
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: originalWindow,
+  });
+});
+
+const makeValue = (overrides?: Partial<PersistedSlice>) => {
+  const conversations = overrides?.chat?.conversations ?? [];
+  const config =
+    overrides?.config ??
+    ({
+      openAIKey: "",
+      anthropicKey: "",
+      googleKey: "",
+      selectedModel: "claude-sonnet-4-6",
+      enabledModels: ["claude-sonnet-4-6"],
+      reasoningLevel: "none",
+    } as PersistedSlice["config"]);
+  return {
+    state: { chat: { conversations }, config },
+    version: 6,
+  };
+};
+
+describe("dedupedJSONStorage", () => {
+  test("first write hits storage", () => {
+    dedupedJSONStorage.setItem(NAME, makeValue());
+    expect(storage.setItem).toHaveBeenCalledTimes(1);
+  });
+
+  test("subsequent writes with identical refs skip storage", () => {
+    const v = makeValue();
+    dedupedJSONStorage.setItem(NAME, v);
+    dedupedJSONStorage.setItem(NAME, v);
+    dedupedJSONStorage.setItem(NAME, v);
+    expect(storage.setItem).toHaveBeenCalledTimes(1);
+  });
+
+  test("60 identical writes (streaming-chunk shape) hit storage exactly once", () => {
+    const v = makeValue();
+    for (let i = 0; i < 60; i++) dedupedJSONStorage.setItem(NAME, v);
+    expect(storage.setItem).toHaveBeenCalledTimes(1);
+  });
+
+  test("write with new conversations ref hits storage", () => {
+    const v1 = makeValue();
+    const v2 = makeValue({
+      chat: { conversations: [...v1.state.chat.conversations] },
+      config: v1.state.config,
+    });
+    dedupedJSONStorage.setItem(NAME, v1);
+    dedupedJSONStorage.setItem(NAME, v2);
+    expect(storage.setItem).toHaveBeenCalledTimes(2);
+  });
+
+  test("write with new config ref hits storage", () => {
+    const v1 = makeValue();
+    const v2 = makeValue({
+      chat: v1.state.chat,
+      config: { ...v1.state.config },
+    });
+    dedupedJSONStorage.setItem(NAME, v1);
+    dedupedJSONStorage.setItem(NAME, v2);
+    expect(storage.setItem).toHaveBeenCalledTimes(2);
+  });
+
+  test("getItem round-trips through JSON.parse", async () => {
+    const v = makeValue();
+    dedupedJSONStorage.setItem(NAME, v);
+    const got = await dedupedJSONStorage.getItem(NAME);
+    expect(got).not.toBeNull();
+    expect(got?.state.chat.conversations).toEqual([]);
+    expect(got?.version).toBe(6);
+  });
+
+  test("getItem returns null when storage is empty", async () => {
+    expect(await dedupedJSONStorage.getItem(NAME)).toBeNull();
+  });
+
+  test("getItem returns null on malformed payload", async () => {
+    storage.setItem(NAME, "{not json");
+    expect(await dedupedJSONStorage.getItem(NAME)).toBeNull();
+  });
+
+  test("quota error is caught; cache resets so next mutation retries", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const v1 = makeValue();
+    dedupedJSONStorage.setItem(NAME, v1);
+    expect(storage.setItem).toHaveBeenCalledTimes(1);
+
+    const quotaError = new Error("quota exceeded");
+    quotaError.name = "QuotaExceededError";
+    storage.setItem.mockImplementationOnce(() => {
+      throw quotaError;
+    });
+
+    const v2 = makeValue({
+      chat: { conversations: [...v1.state.chat.conversations, {} as never] },
+      config: v1.state.config,
+    });
+    dedupedJSONStorage.setItem(NAME, v2);
+    expect(warnSpy).toHaveBeenCalled();
+
+    // After quota failure, dedupe refs are reset; same payload retries on next call.
+    storage.setItem.mockClear();
+    dedupedJSONStorage.setItem(NAME, v2);
+    expect(storage.setItem).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockRestore();
+  });
+
+  test("removeItem clears dedupe cache so next write hits storage", () => {
+    const v = makeValue();
+    dedupedJSONStorage.setItem(NAME, v);
+    dedupedJSONStorage.removeItem(NAME);
+    storage.setItem.mockClear();
+    dedupedJSONStorage.setItem(NAME, v);
+    expect(storage.setItem).toHaveBeenCalledTimes(1);
+  });
+});

--- a/store/persistStorage.ts
+++ b/store/persistStorage.ts
@@ -16,6 +16,11 @@ const isQuotaError = (error: unknown): boolean => {
   return /quota/i.test(error.message);
 };
 
+/**
+ * Skips writes when the persisted chat/config references match lastConvos and
+ * lastConfig. Persisted slices must use immutable updates for those fields; an
+ * in-place mutation would keep the same reference and skip the storage write.
+ */
 export const dedupedJSONStorage: PersistStorage<PersistedSlice> = {
   getItem: (name) => {
     if (typeof window === "undefined") return null;

--- a/store/persistStorage.ts
+++ b/store/persistStorage.ts
@@ -1,0 +1,63 @@
+import type { PersistStorage, StorageValue } from "zustand/middleware";
+import type { Conversation } from "./slices/chats/types";
+import type { Config } from "./types";
+
+export interface PersistedSlice {
+  chat: { conversations: Conversation[] };
+  config: Config;
+}
+
+let lastConvos: Conversation[] | null = null;
+let lastConfig: Config | null = null;
+
+const isQuotaError = (error: unknown): boolean => {
+  if (!(error instanceof Error)) return false;
+  if (error.name === "QuotaExceededError") return true;
+  return /quota/i.test(error.message);
+};
+
+export const dedupedJSONStorage: PersistStorage<PersistedSlice> = {
+  getItem: (name) => {
+    if (typeof window === "undefined") return null;
+    const raw = window.localStorage.getItem(name);
+    if (!raw) return null;
+    try {
+      return JSON.parse(raw) as StorageValue<PersistedSlice>;
+    } catch {
+      return null;
+    }
+  },
+  setItem: (name, value) => {
+    if (typeof window === "undefined") return;
+    const convos = value.state.chat.conversations;
+    const config = value.state.config;
+    if (convos === lastConvos && config === lastConfig) return;
+    lastConvos = convos;
+    lastConfig = config;
+    try {
+      window.localStorage.setItem(
+        name,
+        JSON.stringify({ state: value.state, version: value.version })
+      );
+    } catch (error) {
+      // Reset cached refs so the next mutation retries the write rather than
+      // silently dropping it.
+      lastConvos = null;
+      lastConfig = null;
+      if (isQuotaError(error)) {
+        console.warn(
+          "[chat-store] localStorage quota exceeded; chat history not saved. " +
+            "Consider deleting old conversations."
+        );
+        return;
+      }
+      console.warn("[chat-store] persist write failed:", error);
+    }
+  },
+  removeItem: (name) => {
+    if (typeof window === "undefined") return;
+    window.localStorage.removeItem(name);
+    lastConvos = null;
+    lastConfig = null;
+  },
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
             "components/**/*.test.{ts,tsx}",
             "constants/**/*.test.ts",
             "lib/**/*.test.ts",
+            "store/**/*.test.ts",
           ],
         },
       },


### PR DESCRIPTION
## Summary
- Skip redundant Zustand persist writes when streamed chunks do not change persisted chat/config refs
- Add quota-safe storage handling with unit coverage for dedupe behavior
- Memoize code blocks so completed blocks avoid repeated syntax highlighting during streaming

## Verification
- npx tsc --noEmit
- bun lint (passes with existing nav-chat-history a11y warnings)
- bun test --project=unit
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Optimized component rendering to reduce unnecessary re-renders.

* **Stability**
  * Improved state persistence with enhanced deduplication and error handling for storage quota issues.

* **Tests**
  * Added comprehensive test coverage for state persistence functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->