### PR TITLE
docs: add MIT license badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 # Circle
 
 ## Database Setup


### PR DESCRIPTION
## Summary

- Adds MIT license badge at the top of the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)